### PR TITLE
Feat/report to ticket links

### DIFF
--- a/test/features/create.notification.feature
+++ b/test/features/create.notification.feature
@@ -1,3 +1,4 @@
+@issue=536842
 Feature: ProveConnectivityOnCdpPipeline
 
   Scenario: This feature has been written purely to prove that a test can run

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -95,7 +95,9 @@ export const config = {
       'allure',
       {
         outputDir: 'allure-results',
-        useCucumberStepReporter: true
+        useCucumberStepReporter: true,
+        issueLinkTemplate:
+          'https://dev.azure.com/defragovuk/DEFRA-Marine-Licensing/_workitems/edit/{}'
       }
     ]
   ],

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -161,7 +161,9 @@ export const config = {
       'allure',
       {
         outputDir: 'allure-results',
-        useCucumberStepReporter: true
+        useCucumberStepReporter: true,
+        issueLinkTemplate:
+          'https://dev.azure.com/defragovuk/DEFRA-Marine-Licensing/_workitems/edit/{}'
       }
     ]
   ],


### PR DESCRIPTION
This allows linking from the allure reports to related workitems in AzureDevOps for easy traceability and tracking