### PR TITLE
Adding validation tests for the Site Details task

### DIFF
--- a/.cursor/rules/avoid.over.engineering.mdc
+++ b/.cursor/rules/avoid.over.engineering.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule applies when creating test data models, factories, or any test infrastructure code. It's easy to get excited and create comprehensive, feature-rich test utilities that end up being unused.
+globs: 
 alwaysApply: false
 ---
 # Avoid Over-Engineering in Test Code

--- a/.cursor/rules/bdd.rules.mdc
+++ b/.cursor/rules/bdd.rules.mdc
@@ -10,13 +10,17 @@ alwaysApply: false
 - **Cardinal Rule**
   - One Scenario, One Behaviour
 - **Good titles** - the title is like the face of the scenario, the first thing people read
-- **Less is more** - keep your scenarios short and sweet <10 steps
+- **Less is more** - keep your scenarios short and sweet <5 steps - only more than 3 in exceptional circumstances
 - **Focus features on customer needs**
 - **Always use Given, When, Then in that order and only that order** - don't repeat them; any single When-Then pair denotes an individual behaviour
 - **Respect the integrity of the step types**:
   - Given sets up initial state
   - When performs an action
   - Then verifies the outcome
+- **Prioritize value over volume** - focus on high-risk, high-value scenarios rather than testing everything:
+  - Prefer testing complex user flows and key validations
+  - Avoid redundant tests where behavior is implicitly verified in other scenarios
+  - Basic page display tests are low priority if the page is part of other test flows
 
 ## Implementation Mapping
 
@@ -25,7 +29,7 @@ alwaysApply: false
 - **When steps** → User actions that map to high-level **Tasks** 
 - **Then steps** → Verification that maps to **Interactions** with `ensure` prefix
 
-> 📖 **See:** [`screenplay-pattern.mdc`](mdc:marine-licensing-journey-tests/screenplay-pattern.mdc) for implementation details
+> 📖 **See:** [`screenplay-pattern.mdc`](mdc:marine-licensing-journey-tests/marine-licensing-journey-tests/marine-licensing-journey-tests/screenplay-pattern.mdc) for implementation details
 
 ## Strategic Context
 
@@ -33,13 +37,21 @@ alwaysApply: false
 - Use HTSM quality criteria to identify what behaviors to test
 - Consider risk areas and product factors when designing scenarios
 - Focus on customer value and real user workflows
+- **Implicit vs. Explicit Testing:**
+  - If a page is traversed as part of other test flows, its basic display is implicitly tested
+  - Explicitly test only what adds unique value (validation, specific interactions, etc.)
+  - Don't create separate scenarios just to verify a page appears correctly if it's already part of other flows
 
-> 📖 **See:** [`htsm.mdc`](mdc:marine-licensing-journey-tests/htsm.mdc) for strategic test thinking
+> 📖 **See:** [`htsm.mdc`](mdc:marine-licensing-journey-tests/marine-licensing-journey-tests/marine-licensing-journey-tests/htsm.mdc) for strategic test thinking
 
 ## File Organization
 
 - Feature files go in `test/features/`
 - Step definitions go in `test/steps/`
 - Screenplay implementation follows the patterns in `test-infrastructure/screenplay/`
+- **Feature types follow these patterns**:
+  - `*.feature` - Standard user journey scenarios
+  - `validation.*.feature` - Validation-specific scenarios
+  - `back.and.cancel.*.feature` - Navigation scenarios for back and cancel actions
 
-> 📖 **See:** [`project-structure.mdc`](mdc:marine-licensing-journey-tests/project-structure.mdc) for complete organization rules
+> 📖 **See:** [`project-structure.mdc`](mdc:marine-licensing-journey-tests/marine-licensing-journey-tests/marine-licensing-journey-tests/project-structure.mdc) for complete organization rules

--- a/.cursor/rules/defensive.coding.patterns.mdc
+++ b/.cursor/rules/defensive.coding.patterns.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule covers defensive coding practices discovered while refactoring test automation code. We found patterns of both good and bad defensive coding that need clear guidelines.
+globs: 
 alwaysApply: false
 ---
 # Defensive Coding Patterns

--- a/.cursor/rules/documentation.link.integrity.mdc
+++ b/.cursor/rules/documentation.link.integrity.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule ensures that when creating new `.mdc` rule files, they are properly linked in the main README so they can be discovered and used.
+globs: 
 alwaysApply: false
 ---
 # Documentation Link Integrity
@@ -71,24 +71,24 @@ fi
 Don't just link the file - explain what someone learns from it:
 
 ```markdown
-| [`new-rule.mdc`](./new-rule.mdc) | What specific problem this solves or pattern it teaches |
+| [`new-rule.mdc`](mdc:marine-licensing-journey-tests/new-rule.mdc) | What specific problem this solves or pattern it teaches |
 ```
 
 ## Link Format Standards
 
 ### Table Format
 ```markdown
-| [`rule-name.mdc`](./rule-name.mdc) | Brief description of what it teaches |
+| [`rule-name.mdc`](mdc:marine-licensing-journey-tests/rule-name.mdc) | Brief description of what it teaches |
 ```
 
 ### Inline Format (for references)
 ```markdown
-See [`rule-name.mdc`](./rule-name.mdc) for details on...
+See [`rule-name.mdc`](mdc:marine-licensing-journey-tests/rule-name.mdc) for details on...
 ```
 
 ### Cross-References
 ```markdown
-This works with [`related-rule.mdc`](./related-rule.mdc) to provide...
+This works with [`related-rule.mdc`](mdc:marine-licensing-journey-tests/related-rule.mdc) to provide...
 ```
 
 ## Automation Opportunities
@@ -114,7 +114,7 @@ Consider automating the link generation:
 # Generate links for all .mdc files
 for file in .cursor/rules/*.mdc; do
   name=$(basename "$file")
-  echo "| [\`$name\`](./$name) | TODO: Add description |"
+  echo "| [\`$name\`](mdc:marine-licensing-journey-tests/$name) | TODO: Add description |"
 done
 ```
 

--- a/.cursor/rules/duplicate.action.prevention.mdc
+++ b/.cursor/rules/duplicate.action.prevention.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule addresses the problem of duplicate actions in test automation, particularly when tasks already handle certain actions internally but additional actions are added manually.
+globs: 
 alwaysApply: false
 ---
 # Duplicate Action Prevention

--- a/.cursor/rules/environmental.tool.selection.mdc
+++ b/.cursor/rules/environmental.tool.selection.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule addresses the importance of selecting tools that match the environment and context, rather than blindly using whatever happens to be available.
+globs: 
 alwaysApply: false
 ---
 # Environmental Tool Selection

--- a/.cursor/rules/logical.consistency.validation.mdc
+++ b/.cursor/rules/logical.consistency.validation.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule addresses logical inconsistencies in data models, particularly when related fields should have consistent values but don't due to mapping errors or misunderstanding of business logic.
+globs: 
 alwaysApply: false
 ---
 # Logical Consistency Validation

--- a/.cursor/rules/stop.overengineering.and.making.stuff.up.mdc
+++ b/.cursor/rules/stop.overengineering.and.making.stuff.up.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule applies to ALL code generation, refactoring, and test automation work. I have a tendency to over-engineer solutions and create unnecessary complexity.
+globs: 
 alwaysApply: false
 ---
 # Stop Over-Engineering and Making Stuff Up

--- a/.cursor/rules/test.error.handling.mdc
+++ b/.cursor/rules/test.error.handling.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule applies when handling errors, validation failures, or unexpected conditions in test automation code. Test code should use proper test framework assertions rather than generic error throwing.
+globs: 
 alwaysApply: false
 ---
 # Test Error Handling

--- a/.cursor/rules/test.execution.patience.mdc
+++ b/.cursor/rules/test.execution.patience.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: This rule applies to running tests in the marine licensing test automation project, particularly end-to-end tests that take time to execute.
+globs: 
 alwaysApply: false
 ---
 # Test Execution Patience

--- a/.cursor/user-stories/README.md
+++ b/.cursor/user-stories/README.md
@@ -4,14 +4,14 @@ This directory contains user stories for the marine licensing application under 
 
 ## User Stories Overview
 
-| Story ID | Title                                         | User Story File                                                                                                      | Feature Files                                                                                                                                                                                                                                                                |
-| -------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ML-1     | Provide Project Name and Create Exemption     | [ML-1.provide.project.name.and.create.exemption.mdc](./ML-1.provide.project.name.and.create.exemption.mdc)           | [project.name.feature](../../test/features/project.name.feature), [validation.project.name.feature](../../test/features/validation.project.name.feature)                                                                                                                     |
-| ML-9     | View the Task List                            | [ML-9.view.the.task.list.mdc](./ML-9.view.the.task.list.mdc)                                                         | [task.list.feature](../../test/features/task.list.feature), [project.name.feature](../../test/features/project.name.feature)                                                                                                                                                 |
-| ML-12    | Provide or Withhold Public Register Content   | [ML-12.provide.or.withhold.public.register.content.mdc](./ML-12.provide.or.withhold.public.register.content.mdc)     | [public.register.feature](../../test/features/public.register.feature), [validation.public.register.feature](../../test/features/validation.public.register.feature), [back.and.cancel.public.register.feature](../../test/features/back.and.cancel.public.register.feature) |
-| ML-16    | Choose File Upload or Manual Coordinate Entry | [ML-16.choose.file.upload.or.manual.coordinate.entry.mdc](./ML-16.choose.file.upload.or.manual.coordinate.entry.mdc) | [site.details.manual.circle.feature](../../test/features/site.details.manual.circle.feature), [site.details.manual.polygon.feature](../../test/features/site.details.manual.polygon.feature)                                                                                 |
-| ML-17    | Choose Circle or Coordinate List Entry        | [ML-17.choose.circle.or.coordinate.list.entry.mdc](./ML-17.choose.circle.or.coordinate.list.entry.mdc)               | [site.details.manual.circle.feature](../../test/features/site.details.manual.circle.feature), [site.details.manual.polygon.feature](../../test/features/site.details.manual.polygon.feature)                                                                                 |
-| ML-18    | Choose Coordinate System                      | [ML-18.choose.coordinate.system.mdc](./ML-18.choose.coordinate.system.mdc)                                           | [site.details.manual.circle.feature](../../test/features/site.details.manual.circle.feature), [site.details.manual.polygon.feature](../../test/features/site.details.manual.polygon.feature)                                                                                 |
+| Story ID | Title                                         | User Story File                                                                                                      | Feature Files                                                                                                                                                                                                                                                                                                                                                                                            |
+| -------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ML-1     | Provide Project Name and Create Exemption     | [ML-1.provide.project.name.and.create.exemption.mdc](./ML-1.provide.project.name.and.create.exemption.mdc)           | [project.name.feature](../../test/features/project.name.feature), [validation.project.name.feature](../../test/features/validation.project.name.feature)                                                                                                                                                                                                                                                 |
+| ML-9     | View the Task List                            | [ML-9.view.the.task.list.mdc](./ML-9.view.the.task.list.mdc)                                                         | [task.list.feature](../../test/features/task.list.feature), [project.name.feature](../../test/features/project.name.feature)                                                                                                                                                                                                                                                                             |
+| ML-12    | Provide or Withhold Public Register Content   | [ML-12.provide.or.withhold.public.register.content.mdc](./ML-12.provide.or.withhold.public.register.content.mdc)     | [public.register.feature](../../test/features/public.register.feature), [validation.public.register.feature](../../test/features/validation.public.register.feature), [back.and.cancel.public.register.feature](../../test/features/back.and.cancel.public.register.feature)                                                                                                                             |
+| ML-16    | Choose File Upload or Manual Coordinate Entry | [ML-16.choose.file.upload.or.manual.coordinate.entry.mdc](./ML-16.choose.file.upload.or.manual.coordinate.entry.mdc) | [site.details.manual.circle.feature](../../test/features/site.details.manual.circle.feature), [site.details.manual.polygon.feature](../../test/features/site.details.manual.polygon.feature), [validation.site.details.feature](../../test/features/validation.site.details.feature), [back.and.cancel.site.details.feature](../../test/features/back.and.cancel.site.details.feature) (not implemented) |
+| ML-17    | Choose Circle or Coordinate List Entry        | [ML-17.choose.circle.or.coordinate.list.entry.mdc](./ML-17.choose.circle.or.coordinate.list.entry.mdc)               | [site.details.manual.circle.feature](../../test/features/site.details.manual.circle.feature), [site.details.manual.polygon.feature](../../test/features/site.details.manual.polygon.feature), [validation.site.details.feature](../../test/features/validation.site.details.feature), [back.and.cancel.site.details.feature](../../test/features/back.and.cancel.site.details.feature) (not implemented) |
+| ML-18    | Choose Coordinate System                      | [ML-18.choose.coordinate.system.mdc](./ML-18.choose.coordinate.system.mdc)                                           | [site.details.manual.circle.feature](../../test/features/site.details.manual.circle.feature), [site.details.manual.polygon.feature](../../test/features/site.details.manual.polygon.feature), [validation.site.details.feature](../../test/features/validation.site.details.feature), [back.and.cancel.site.details.feature](../../test/features/back.and.cancel.site.details.feature) (not implemented) |
 
 ## Story Status
 
@@ -19,12 +19,24 @@ This directory contains user stories for the marine licensing application under 
 - ✅ **ML-9**: Task list display and navigation
 - ✅ **ML-12**: Public register consent and withholding
 - 🔄 **ML-16**: Choose file upload or manual coordinate entry
+  - ✅ Happy path implemented
+  - ✅ Validation implemented
+  - 🚧 Back and cancel functionality not implemented
 - 🔄 **ML-17**: Choose how to enter site coordinates
+  - ✅ Happy path implemented
+  - ✅ Validation implemented
+  - 🚧 Back and cancel functionality not implemented
 - 🔄 **ML-18**: Choose coordinate system for site location
+  - ✅ Happy path implemented
+  - ✅ Validation implemented
+  - 🚧 Back and cancel functionality not implemented
 
 ## Feature File Tags
 
 Feature files are tagged with `@issue=ML-n` where `n` corresponds to the user story number. This allows for easy tracking between requirements and test implementation.
+
+- `@wip` tags are used for features currently under development
+- `@run-only` can be used to specifically target features during development
 
 ## Usage
 

--- a/test-infrastructure/pages/how.do.you.want.to.enter.the.coordinates.page.js
+++ b/test-infrastructure/pages/how.do.you.want.to.enter.the.coordinates.page.js
@@ -2,6 +2,7 @@ export default class HowDoYouWantToEnterTheCoordinatesPage {
   static circularSite = '#coordinatesEntry'
   static boundarySite = '#coordinatesEntry-2'
   static saveAndContinue = 'button[type="submit"]'
+  static coordinatesEntryError = '#coordinatesEntry-error'
 
   static getSiteTypeSelector(siteType) {
     if (siteType === 'circle') return this.circularSite

--- a/test-infrastructure/pages/how.do.you.want.to.provide.coordinates.page.js
+++ b/test-infrastructure/pages/how.do.you.want.to.provide.coordinates.page.js
@@ -2,6 +2,7 @@ export default class HowDoYouWantToProvideCoordinatesPage {
   static uploadCoordinates = '#coordinatesType'
   static enterCoordinates = '#coordinatesType-2'
   static saveAndContinue = 'button[type="submit"]'
+  static coordinatesTypeError = '#coordinatesType-error'
 
   static getCoordinatesInputMethodSelector(coordinatesInputMethod) {
     if (coordinatesInputMethod === 'file-upload') return this.uploadCoordinates

--- a/test-infrastructure/pages/what.coordinate.system.page.js
+++ b/test-infrastructure/pages/what.coordinate.system.page.js
@@ -2,6 +2,7 @@ export default class WhatCoordinateSystemPage {
   static wgs84 = '#coordinateSystem'
   static osgb36 = '#coordinateSystem-2'
   static saveAndContinue = 'button[type="submit"]'
+  static coordinatesSystemError = '#coordinateSystem-error'
 
   static getCoordinateSystemSelector(system) {
     if (system === 'WGS84') return this.wgs84

--- a/test-infrastructure/screenplay/tasks/fill.form.js
+++ b/test-infrastructure/screenplay/tasks/fill.form.js
@@ -1,27 +1,10 @@
 import Task from '../base/task.js'
 
-/**
- * A generic task for filling out forms without saving/submitting them.
- * This is particularly useful for testing cancel/back behaviors.
- */
 export default class FillForm extends Task {
-  /**
-   * Creates a task to fill out a form by performing a series of interactions
-   * without saving or submitting the form.
-   *
-   * @param {Function} formFiller - A function that takes an actor and performs the form filling interactions
-   * @returns {FillForm} A new FillForm task
-   */
   static withInteractions(formFiller) {
     return new FillForm(formFiller)
   }
 
-  /**
-   * Creates a task to fill out a public register form with withholding information
-   *
-   * @param {string} reason - The reason for withholding information
-   * @returns {FillForm} A new FillForm task
-   */
   static publicRegisterWithhold(reason) {
     return new FillForm(async (actor) => {
       const PublicRegisterPage = (
@@ -34,6 +17,36 @@ export default class FillForm extends Task {
       if (reason && reason.length > 0) {
         await browseTheWeb.sendKeys(PublicRegisterPage.withholdReason, reason)
       }
+    })
+  }
+
+  static chooseToEnterCoordinatesManually() {
+    return new FillForm(async (actor) => {
+      const HowDoYouWantToProvideCoordinatesPage = (
+        await import(
+          '~/test-infrastructure/pages/how.do.you.want.to.provide.coordinates.page'
+        )
+      ).default
+      const browseTheWeb = actor.ability
+
+      await browseTheWeb.click(
+        HowDoYouWantToProvideCoordinatesPage.enterCoordinates
+      )
+    })
+  }
+
+  static provideASinglePointForACircularSite() {
+    return new FillForm(async (actor) => {
+      const HowDoYouWantToEnterTheCoordinatesPage = (
+        await import(
+          '~/test-infrastructure/pages/how.do.you.want.to.enter.the.coordinates.page.js'
+        )
+      ).default
+      const browseTheWeb = actor.ability
+
+      await browseTheWeb.click(
+        HowDoYouWantToEnterTheCoordinatesPage.circularSite
+      )
     })
   }
 

--- a/test-strategy/bdd-rules.md
+++ b/test-strategy/bdd-rules.md
@@ -5,11 +5,41 @@
 - **Golden Rule**: Write Gherkin so people unfamiliar with marine licensing will understand it
 - **Cardinal Rule**: One Scenario, One Behaviour
 - **Structure**: Always use Given-When-Then in that order, no repetition
-- **Brevity**: Keep scenarios under 5 steps, only have more in exceptional circumstances
+- **Brevity**: Keep scenarios under 5 steps, only have more than 3 in exceptional circumstances
 - **Step Integrity**: Given = setup, When = action, Then = verification
 - **Business Value**: Titles clearly describe the business value being delivered
 - **Domain Context**: Use realistic marine licensing terminology and workflows
 - **User-Centred**: Cover important journeys from personas (Zofia, Amy, Fatima)
+- **Test Smart, Not Everything**: Prioritize scenarios based on risk and value, not completeness
+
+## Test Prioritization
+
+### High Priority
+
+- Complex user journeys with multiple steps
+- Business-critical validations and edge cases
+- Scenarios with high risk of defects
+- Back/cancel tests that verify important state changes or preservation
+- Navigation scenarios that affect data persistence
+
+### Low Priority
+
+- Basic page display tests when pages are traversed in other scenarios
+- Simple navigational tests with limited business logic
+- Scenarios that are implicitly tested through other flows
+- Navigation tests without state change verification
+
+## Implicit vs. Explicit Testing
+
+- **Implicit Testing**: When features are indirectly verified through other test flows
+
+  - Example: If a page display is verified as part of a validation scenario, a separate "page display" scenario is unnecessary
+  - Page transitions are implicitly tested in user journey scenarios
+
+- **Explicit Testing**: Specifically testing a feature as the primary focus
+  - Validation scenarios should be explicit tests
+  - Complex business rules require explicit verification
+  - State preservation/change during navigation requires explicit tests
 
 ## Marine Licensing Example
 
@@ -64,6 +94,16 @@ Then the project name is displayed on the Public register page
 - **Public register interactions** - Search and view exemption information
 - **Compliance verification** - Environmental and regulatory checks
 - **Multi-stakeholder flows** - Applicant, MMO, and public interactions
+
+## Feature Organization
+
+To maintain separation of concerns, we organize feature files by test type:
+
+- **Standard journey features** (`*.feature`) - Happy path user flows and core functionality
+- **Validation features** (`validation.*.feature`) - Error validation scenarios
+- **Back and cancel features** (`back.and.cancel.*.feature`) - Navigation behavior when users go back or cancel
+
+This structure ensures scenarios have a single responsibility and makes it easier to locate specific types of tests.
 
 ---
 

--- a/test/features/back.and.cancel.public.register.feature
+++ b/test/features/back.and.cancel.public.register.feature
@@ -1,26 +1,28 @@
 @issue=ML-12
 Feature: Back and Cancel from Public register: State management when clicking back or cancel
 
+@wip
  Scenario: Cancelling out of the public register task when no information has previously been saved
     Given the Public register page is displayed
     When completing the public register task but cancelling out
     Then the task list page is displayed
     And the "Public register" task status is "Incomplete"
     And any changes made on the public register page before cancelling are not saved
-
+@wip
   Scenario: Using the back link from the public register task when no information has previously been saved
     Given the Public register page is displayed
     When completing the public register task but selecting to go back
     Then the task list page is displayed
     And the "Public register" task status is "Incomplete"
     And any changes made on the public register page before going back are not saved
-
+@wip
   Scenario: Cancelling out of the public register task when information has previously been saved
     Given the Public register task has been completed with consent
     When changing the public register information to withhold but cancelling out
     Then the "Public register" task status is "Completed"
     And the previously saved changes are pre-populated
 
+@wip
   Scenario: Using the back link from the public register task when information has previously been saved
     Given the Public register task has been completed with consent
     When changing the public register information to withhold but selecting to go back

--- a/test/features/back.and.cancel.site.details.feature
+++ b/test/features/back.and.cancel.site.details.feature
@@ -1,0 +1,44 @@
+@issue=ML-16 @issue=ML-17 @issue=ML-18
+Feature: Back and Cancel from Site details: State management when clicking back or cancel
+
+  @wip
+  Scenario: Cancelling out of the site details task when no information has previously been saved
+    Given the "How do you want to provide the site location?" page is displayed
+    When the Cancel button is clicked
+    Then the task list is displayed with "Site details" status as "Incomplete" and no changes saved
+
+  @wip
+  Scenario: Using the back link from the site location page
+    Given the "How do you want to provide the site location?" page is displayed
+    When the Back link is clicked
+    Then the task list is displayed with "Site details" status as "Incomplete" and no changes saved
+
+  @wip
+  Scenario: Using the back link from the coordinate entry method page preserves selections
+    Given the "How do you want to enter the coordinates?" page is displayed with "Enter the coordinates of the site manually" previously selected
+    When the Back link is clicked
+    Then the "How do you want to provide the site location?" page is displayed with previous selection preserved
+
+  @wip
+  Scenario: Using the back link from the coordinate system page preserves selections
+    Given the "Which coordinate system do you want to use?" page is displayed with "Enter multiple sets of coordinates to mark the boundary of the site" previously selected
+    When the Back link is clicked
+    Then the "How do you want to enter the coordinates?" page is displayed with previous selection preserved
+
+  @wip
+  Scenario: Cancelling out of the coordinate entry method page discards changes
+    Given the "How do you want to enter the coordinates?" page is displayed with a selection made
+    When the Cancel button is clicked
+    Then the task list is displayed with "Site details" status as "Incomplete" and no changes saved
+
+  @wip
+  Scenario: Cancelling out of the coordinate system page discards changes
+    Given the "Which coordinate system do you want to use?" page is displayed with a selection made
+    When the Cancel button is clicked
+    Then the task list is displayed with "Site details" status as "Incomplete" and no changes saved
+
+  @wip
+  Scenario: Partially completed site details are not saved when cancelling
+    Given the user has navigated through multiple site details pages with selections made
+    When the Cancel button is clicked
+    Then the task list is displayed with "Site details" status as "Incomplete" and all selections discarded

--- a/test/features/validation.project.name.feature
+++ b/test/features/validation.project.name.feature
@@ -4,7 +4,7 @@ Feature: Validation of Project name: the project name is validated
   Scenario Outline: Error when project name is <projectName>
     Given the project name page is displayed
     When entering and saving the project with name "<projectName>"
-    Then the error "<errorMessage>" is displayed
+    Then the project name error "<errorMessage>" is displayed
 
     Examples:
       | errorMessage                                  | projectName                                                                                                                                                                                                                                                                        |

--- a/test/features/validation.site.details.feature
+++ b/test/features/validation.site.details.feature
@@ -5,16 +5,19 @@ Feature: Validation of Site details: the user is prevented from proceeding with 
   So that I can correct errors before submitting my marine licence application
 
   Scenario: User is prevented from proceeding without selecting a site location input method
-    Given the "How do you want to provide the site location?" page is displayed
+    Given a user is providing site details
+    And the "How do you want to provide the site location?" page has been reached
     When the Continue button is clicked without selecting a site location option
     Then the coordinates type error: "Select how you want to provide the site location" is displayed
 
   Scenario: User is prevented from proceeding without selecting a coordinate entry method
-    Given the "How do you want to enter the coordinates?" page is displayed
+    Given a user is providing site details
+    And the "How do you want to enter the coordinates?" page has been reached
     When the Continue button is clicked without selecting a coordinate entry method
     Then the coordinates entry method error: "Select how you want to enter the coordinates" is displayed
 
   Scenario: User is prevented from proceeding without selecting a coordinate system
-    Given the "Which coordinate system do you want to use?" page is displayed
+    Given a user is providing site details
+    And the "Which coordinate system do you want to use?" page has been reached
     When the Continue button is clicked without selecting a coordinate system
     Then the coordinates system error "Select which coordinate system you want to use" is displayed

--- a/test/features/validation.site.details.feature
+++ b/test/features/validation.site.details.feature
@@ -1,0 +1,23 @@
+@issue=ML-16 @issue=ML-17 @issue=ML-18
+Feature: Validation of Site details: the user is prevented from proceeding with invalid site location information
+  As an applicant
+  I want to be notified when I have not provided required site location information
+  So that I can correct errors before submitting my marine licence application
+
+  @wip
+  Scenario: User is prevented from proceeding without selecting a site location input method
+    Given the "How do you want to provide the site location?" page is displayed
+    When the Continue button is clicked without selecting a site location option
+    Then the error "Select how you want to provide the site location" is displayed
+
+  @wip
+  Scenario: User is prevented from proceeding without selecting a coordinate entry method
+    Given the "How do you want to enter the coordinates?" page is displayed
+    When the Continue button is clicked without selecting a coordinate entry method
+    Then the error "Select how you want to enter the coordinates" is displayed
+
+  @wip
+  Scenario: User is prevented from proceeding without selecting a coordinate system
+    Given the "Which coordinate system do you want to use?" page is displayed
+    When the Continue button is clicked without selecting a coordinate system
+    Then the error "Select which coordinate system you want to use" is displayed

--- a/test/features/validation.site.details.feature
+++ b/test/features/validation.site.details.feature
@@ -4,20 +4,17 @@ Feature: Validation of Site details: the user is prevented from proceeding with 
   I want to be notified when I have not provided required site location information
   So that I can correct errors before submitting my marine licence application
 
-  @wip
   Scenario: User is prevented from proceeding without selecting a site location input method
     Given the "How do you want to provide the site location?" page is displayed
     When the Continue button is clicked without selecting a site location option
-    Then the error "Select how you want to provide the site location" is displayed
+    Then the coordinates type error: "Select how you want to provide the site location" is displayed
 
-  @wip
   Scenario: User is prevented from proceeding without selecting a coordinate entry method
     Given the "How do you want to enter the coordinates?" page is displayed
     When the Continue button is clicked without selecting a coordinate entry method
-    Then the error "Select how you want to enter the coordinates" is displayed
+    Then the coordinates entry method error: "Select how you want to enter the coordinates" is displayed
 
-  @wip
   Scenario: User is prevented from proceeding without selecting a coordinate system
     Given the "Which coordinate system do you want to use?" page is displayed
     When the Continue button is clicked without selecting a coordinate system
-    Then the error "Select which coordinate system you want to use" is displayed
+    Then the coordinates system error "Select which coordinate system you want to use" is displayed

--- a/test/steps/project.name.steps.js
+++ b/test/steps/project.name.steps.js
@@ -54,11 +54,14 @@ When('the project name is updated', async function () {
   await this.actor.attemptsTo(CompleteProjectName.now())
 })
 
-Then('the error {string} is displayed', async function (errorMessage) {
-  await this.actor.attemptsTo(
-    EnsureErrorDisplayed.is(ProjectNamePage.projectNameError, errorMessage)
-  )
-})
+Then(
+  'the project name error {string} is displayed',
+  async function (errorMessage) {
+    await this.actor.attemptsTo(
+      EnsureErrorDisplayed.is(ProjectNamePage.projectNameError, errorMessage)
+    )
+  }
+)
 
 Then('the project name is pre-populated', async function () {
   await this.actor.attemptsTo(EnsureThatProjectName.isCorrect())

--- a/test/steps/site.details.validation.steps.js
+++ b/test/steps/site.details.validation.steps.js
@@ -1,0 +1,130 @@
+import { Given, Then, When } from '@cucumber/cucumber'
+import { browser } from '@wdio/globals'
+import WhatCoordinateSystemPage from '~/test-infrastructure/pages/what.coordinate.system.page'
+import HowDoYouWantToEnterTheCoordinatesPage from '~/test-infrastructure/pages/how.do.you.want.to.enter.the.coordinates.page'
+import HowDoYouWantToProvideCoordinatesPage from '~/test-infrastructure/pages/how.do.you.want.to.provide.coordinates.page'
+
+import {
+  Actor,
+  ApplyForExemption,
+  BrowseTheWeb,
+  ClickSaveAndContinue,
+  CompleteProjectName,
+  EnsureErrorDisplayed,
+  EnsurePageHeading,
+  FillForm,
+  Navigate,
+  SelectTheTask
+} from '~/test-infrastructure/screenplay'
+
+Given(
+  'the "How do you want to provide the site location?" page is displayed',
+  async function () {
+    this.actor = new Actor('Alice')
+    this.actor.can(new BrowseTheWeb(browser))
+    this.actor.intendsTo(ApplyForExemption.withValidProjectName())
+    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
+    await this.actor.attemptsTo(CompleteProjectName.now())
+    await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
+    await this.actor.attemptsTo(
+      EnsurePageHeading.is('How do you want to provide the site location?')
+    )
+  }
+)
+
+Given(
+  'the "How do you want to enter the coordinates?" page is displayed',
+  async function () {
+    this.actor = new Actor('Alice')
+    this.actor.can(new BrowseTheWeb(browser))
+    this.actor.intendsTo(ApplyForExemption.withValidProjectName())
+    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
+    await this.actor.attemptsTo(CompleteProjectName.now())
+    await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
+
+    await this.actor.attemptsTo(FillForm.chooseToEnterCoordinatesManually())
+    await this.actor.attemptsTo(ClickSaveAndContinue.now())
+    await this.actor.attemptsTo(
+      EnsurePageHeading.is('How do you want to enter the coordinates?')
+    )
+  }
+)
+
+Given(
+  'the "Which coordinate system do you want to use?" page is displayed',
+  async function () {
+    this.actor = new Actor('Alice')
+    this.actor.can(new BrowseTheWeb(browser))
+    this.actor.intendsTo(ApplyForExemption.withValidProjectName())
+    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
+    await this.actor.attemptsTo(CompleteProjectName.now())
+    await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
+
+    await this.actor.attemptsTo(FillForm.chooseToEnterCoordinatesManually())
+    await this.actor.attemptsTo(ClickSaveAndContinue.now())
+
+    await this.actor.attemptsTo(FillForm.provideASinglePointForACircularSite())
+    await this.actor.attemptsTo(ClickSaveAndContinue.now())
+
+    await this.actor.attemptsTo(
+      EnsurePageHeading.is('Which coordinate system do you want to use?')
+    )
+  }
+)
+
+When(
+  'the Continue button is clicked without selecting a site location option',
+  async function () {
+    await this.actor.attemptsTo(ClickSaveAndContinue.now())
+  }
+)
+
+When(
+  'the Continue button is clicked without selecting a coordinate entry method',
+  async function () {
+    await this.actor.attemptsTo(ClickSaveAndContinue.now())
+  }
+)
+
+When(
+  'the Continue button is clicked without selecting a coordinate system',
+  async function () {
+    await this.actor.attemptsTo(ClickSaveAndContinue.now())
+  }
+)
+
+Then(
+  'the coordinates type error: {string} is displayed',
+  async function (errorMessage) {
+    await this.actor.attemptsTo(
+      EnsureErrorDisplayed.is(
+        HowDoYouWantToProvideCoordinatesPage.coordinatesTypeError,
+        errorMessage
+      )
+    )
+  }
+)
+
+Then(
+  'the coordinates entry method error: {string} is displayed',
+  async function (errorMessage) {
+    await this.actor.attemptsTo(
+      EnsureErrorDisplayed.is(
+        HowDoYouWantToEnterTheCoordinatesPage.coordinatesEntryError,
+        errorMessage
+      )
+    )
+  }
+)
+
+Then(
+  'the coordinates system error {string} is displayed',
+  async function (errorMessage) {
+    await this.actor.attemptsTo(
+      EnsureErrorDisplayed.is(
+        WhatCoordinateSystemPage.coordinatesSystemError,
+        errorMessage
+      )
+    )
+  }
+)

--- a/test/steps/site.details.validation.steps.js
+++ b/test/steps/site.details.validation.steps.js
@@ -41,7 +41,6 @@ Given(
     await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
     await this.actor.attemptsTo(CompleteProjectName.now())
     await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
-
     await this.actor.attemptsTo(FillForm.chooseToEnterCoordinatesManually())
     await this.actor.attemptsTo(ClickSaveAndContinue.now())
     await this.actor.attemptsTo(
@@ -59,13 +58,10 @@ Given(
     await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
     await this.actor.attemptsTo(CompleteProjectName.now())
     await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
-
     await this.actor.attemptsTo(FillForm.chooseToEnterCoordinatesManually())
     await this.actor.attemptsTo(ClickSaveAndContinue.now())
-
     await this.actor.attemptsTo(FillForm.provideASinglePointForACircularSite())
     await this.actor.attemptsTo(ClickSaveAndContinue.now())
-
     await this.actor.attemptsTo(
       EnsurePageHeading.is('Which coordinate system do you want to use?')
     )

--- a/test/steps/site.details.validation.steps.js
+++ b/test/steps/site.details.validation.steps.js
@@ -17,15 +17,18 @@ import {
   SelectTheTask
 } from '~/test-infrastructure/screenplay'
 
+Given('a user is providing site details', async function () {
+  this.actor = new Actor('Alice')
+  this.actor.can(new BrowseTheWeb(browser))
+  this.actor.intendsTo(ApplyForExemption.withValidProjectName())
+  await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
+  await this.actor.attemptsTo(CompleteProjectName.now())
+  await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
+})
+
 Given(
-  'the "How do you want to provide the site location?" page is displayed',
+  'the "How do you want to provide the site location?" page has been reached',
   async function () {
-    this.actor = new Actor('Alice')
-    this.actor.can(new BrowseTheWeb(browser))
-    this.actor.intendsTo(ApplyForExemption.withValidProjectName())
-    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
-    await this.actor.attemptsTo(CompleteProjectName.now())
-    await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
     await this.actor.attemptsTo(
       EnsurePageHeading.is('How do you want to provide the site location?')
     )
@@ -33,14 +36,8 @@ Given(
 )
 
 Given(
-  'the "How do you want to enter the coordinates?" page is displayed',
+  'the "How do you want to enter the coordinates?" page has been reached',
   async function () {
-    this.actor = new Actor('Alice')
-    this.actor.can(new BrowseTheWeb(browser))
-    this.actor.intendsTo(ApplyForExemption.withValidProjectName())
-    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
-    await this.actor.attemptsTo(CompleteProjectName.now())
-    await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
     await this.actor.attemptsTo(FillForm.chooseToEnterCoordinatesManually())
     await this.actor.attemptsTo(ClickSaveAndContinue.now())
     await this.actor.attemptsTo(
@@ -50,14 +47,8 @@ Given(
 )
 
 Given(
-  'the "Which coordinate system do you want to use?" page is displayed',
+  'the "Which coordinate system do you want to use?" page has been reached',
   async function () {
-    this.actor = new Actor('Alice')
-    this.actor.can(new BrowseTheWeb(browser))
-    this.actor.intendsTo(ApplyForExemption.withValidProjectName())
-    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp.now())
-    await this.actor.attemptsTo(CompleteProjectName.now())
-    await this.actor.attemptsTo(SelectTheTask.withName('Site details'))
     await this.actor.attemptsTo(FillForm.chooseToEnterCoordinatesManually())
     await this.actor.attemptsTo(ClickSaveAndContinue.now())
     await this.actor.attemptsTo(FillForm.provideASinglePointForACircularSite())


### PR DESCRIPTION
## Description

This PR adds validation tests for the site details section of the marine licensing application. It implements scenarios to verify proper error messages when users attempt to proceed without making required selections in the site location workflow.

The PR also adds the foundation for back and cancel functionality testing in the site details section (marked as @wip for future implementation).

## Checklist

- [x] I have run all tests locally and confirmed they pass.
- [x] I have added tests that cover new functionality or changes.
- [x] I have updated the documentation, including README.md and/or other relevant files.

## Related Tickets/Issues

- ML-16: Site details validation - How do you want to provide site location
- ML-17: Site details validation - How do you want to enter coordinates 
- ML-18: Site details validation - Which coordinate system

## Changes

- [x] Feature/Scenario(s) added
  - Added validation scenarios for site details pages
  - Added back/cancel scenarios for site details (marked as @wip)
- [x] Steps definitions added/modified
  - Added site.details.validation.steps.js
  - Updated fill.form.js with new site details form interactions
- [x] Core framework changes
  - Updated page objects with error selectors for validation

## Notes to Reviewers

The PR implements validation tests for three key site details pages:
1. "How do you want to provide the site location?" page
2. "How do you want to enter the coordinates?" page
3. "Which coordinate system do you want to use?" page

Each test verifies that appropriate error messages are displayed when a user attempts to proceed without making a selection.

The back and cancel scenarios are marked with @wip and will be implemented in a future update.

**Changes to`.cursor\rules` can be ignored**

## Screenshots

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/1286b192-7b35-488c-8f2c-99ce465dea42" />
