### PR TITLE
Fix issue with documentation

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -113,8 +113,7 @@ Rule summaries follow a consistent format:
 ...
 
 ## Related Rules
-- [related-rule-1](../related-rule-1.mdc) - How it relates
-...
+- [code.generation](../code.generation.mdc) - Standards for writing maintainable JavaScript test automation code
 ```
 
 For full documentation, see [rules/README.md](./rules/README.md).

--- a/.cursor/RULES-OPTIMISATION.md
+++ b/.cursor/RULES-OPTIMISATION.md
@@ -77,7 +77,7 @@ Each rule summary follows this consistent structure:
 ...
 
 ## Related Rules
-- [related-rule-1](../related-rule-1.mdc) - How it relates
+- [code.generation](../code.generation.mdc) - Standards for writing maintainable JavaScript test automation code
 ...
 ```
 

--- a/.cursor/rules/summaries/README.md
+++ b/.cursor/rules/summaries/README.md
@@ -39,8 +39,8 @@ Each rule summary follows this consistent format:
 | Example 2 | How to apply in this case |
 
 ## Related Rules
-- [related-rule-1](../related-rule-1.mdc) - How it relates
-- [related-rule-2](../related-rule-2.mdc) - How it relates
+- [code.generation](../code.generation.mdc) - Standards for writing maintainable JavaScript test automation code
+- [playbook.clean.code](../playbook.clean.code.mdc) - Guidelines for maintaining clean, readable, and maintainable code
 ```
 
 ## Usage


### PR DESCRIPTION
## Pull Request Summary

### What Changed

- **Fixed all broken and placeholder links in documentation and rule summaries:**
  - Replaced example/placeholder references to non-existent rule files (e.g., `related-rule-1.mdc`, `related-rule-2.mdc`) with valid links to actual rules (`code.generation.mdc`, `playbook.clean.code.mdc`) in:
    - `.cursor/README.md`
    - `.cursor/RULES-OPTIMISATION.md`
    - `.cursor/rules/summaries/README.md`
- **Ensured all rule references in documentation and summary templates now point to real, existing `.mdc` files.**
- **No other broken or missing rule file links were found** in the `.cursor` documentation or summaries.

### Why

- **Improves documentation integrity and discoverability** by ensuring all rule references are valid and actionable.
- **Prevents confusion for contributors** by removing placeholder/example links that could be mistaken for real rules.
- **Aligns with documentation.link.integrity and documentation.coherence rules** for cross-reference accuracy and quality.

### How to Review

- Check that all links to `.mdc` rule files in the changed documentation now resolve to real files in `.cursor/rules/`.
- Confirm that summary templates and examples use actual rule references, not placeholders.
- No changes to rule content or logic—documentation only.

---

**Ready for review and merge.**  
_This PR contains only documentation and reference fixes; no code or test logic was changed._