### PR TITLE
ML-430: Integrate with Defra ID and run a full exemption notification submission in integrated environments

### DIFF
--- a/test-infrastructure/pages/defra.id.login.page.js
+++ b/test-infrastructure/pages/defra.id.login.page.js
@@ -1,5 +1,8 @@
 export default class DefraIdLoginPage {
   static loginLink = 'a=Log in'
+  static usernameField = '#user_id'
+  static passwordField = '#password'
+  static signInButton = '#continue'
 
   static loginLinkForUser(email) {
     return `a[href*="user=${email}"]`

--- a/test-infrastructure/screenplay/abilities/browse.the.web.js
+++ b/test-infrastructure/screenplay/abilities/browse.the.web.js
@@ -166,4 +166,9 @@ export default class BrowseTheWeb extends Ability {
     const element = await this.getElement(locator)
     await element.setValue(value)
   }
+
+  async waitForEnabled(locator) {
+    const element = await this.getElement(locator)
+    await element.waitForEnabled()
+  }
 }

--- a/test-infrastructure/screenplay/interactions/authenticate.with.a.permanent.user.js
+++ b/test-infrastructure/screenplay/interactions/authenticate.with.a.permanent.user.js
@@ -10,18 +10,22 @@ export default class AuthenticateWithAPermanentUser extends Task {
   async performAs(actor) {
     const browseTheWeb = actor.ability
     const testUser = {
-      email: process.env.TEST_USER_EMAIL,
-      password: process.env.TEST_USER_PASSWORD
+      id: '38 51 93 67 55 42',
+      password: process.env.DEFRA_ID_USER_PASSWORD
     }
 
-    if (!testUser.email || !testUser.password) {
-      expect.fail(
-        'Missing TEST_USER_EMAIL or TEST_USER_PASSWORD environment variables'
-      )
+    if (!testUser.password) {
+      expect.fail('Missing DEFRA_ID_USER_PASSWORD environment variable')
     }
 
-    // This interaction is simplified as we don't have the real Defra ID login page locally.
-    // In a real-world scenario, this would involve filling in the username and password fields.
-    await browseTheWeb.click(DefraIdLoginPage.loginLinkForUser(testUser.email))
+    await browseTheWeb.setValue(DefraIdLoginPage.usernameField, testUser.id)
+    await browseTheWeb.setValue(
+      DefraIdLoginPage.passwordField,
+      testUser.password
+    )
+
+    await browseTheWeb.waitForEnabled(DefraIdLoginPage.signInButton)
+
+    await browseTheWeb.click(DefraIdLoginPage.signInButton)
   }
 }

--- a/test-infrastructure/screenplay/interactions/authenticate.with.a.permanent.user.js
+++ b/test-infrastructure/screenplay/interactions/authenticate.with.a.permanent.user.js
@@ -1,0 +1,27 @@
+import DefraIdLoginPage from '~/test-infrastructure/pages/defra.id.login.page.js'
+import { expect } from 'chai'
+import Task from '../base/task.js'
+
+export default class AuthenticateWithAPermanentUser extends Task {
+  static aPermanentUser() {
+    return new AuthenticateWithAPermanentUser()
+  }
+
+  async performAs(actor) {
+    const browseTheWeb = actor.ability
+    const testUser = {
+      email: process.env.TEST_USER_EMAIL,
+      password: process.env.TEST_USER_PASSWORD
+    }
+
+    if (!testUser.email || !testUser.password) {
+      expect.fail(
+        'Missing TEST_USER_EMAIL or TEST_USER_PASSWORD environment variables'
+      )
+    }
+
+    // This interaction is simplified as we don't have the real Defra ID login page locally.
+    // In a real-world scenario, this would involve filling in the username and password fields.
+    await browseTheWeb.click(DefraIdLoginPage.loginLinkForUser(testUser.email))
+  }
+}

--- a/test-infrastructure/screenplay/tasks/complete.project.name.js
+++ b/test-infrastructure/screenplay/tasks/complete.project.name.js
@@ -15,6 +15,7 @@ export default class CompleteProjectName extends Task {
       expect.fail(ERROR_MESSAGES.MISSING_EXEMPTION('project name'))
     }
     const browseTheWeb = actor.ability
+
     await browseTheWeb.sendKeys(
       ProjectNamePage.projectNameInput,
       exemption.projectName

--- a/test-infrastructure/screenplay/tasks/navigate.js
+++ b/test-infrastructure/screenplay/tasks/navigate.js
@@ -1,5 +1,6 @@
 import ProjectNamePage from '~/test-infrastructure/pages/project.name.page'
 import Task from '../base/task.js'
+import AuthenticateWithAPermanentUser from '../interactions/authenticate.with.a.permanent.user.js'
 import AuthenticateWith from '../interactions/authenticate.with.js'
 
 export default class Navigate extends Task {
@@ -17,16 +18,23 @@ export default class Navigate extends Task {
   }
 
   async performAs(actor) {
+    await actor.ability.navigateTo(this.url)
+
+    if (actor.hasMemoryOf('isAuthenticated')) {
+      return
+    }
+
+    if (process.env.ENVIRONMENT === 'test') {
+      await actor.attemptsTo(AuthenticateWithAPermanentUser.aPermanentUser())
+      actor.remembers('isAuthenticated', true)
+      return
+    }
+
     if (!actor.hasMemoryOf('testUser')) {
       const testUser = await actor.ability.registerTestUser(actor.name)
       actor.remembers('testUser', testUser)
     }
-
-    await actor.ability.navigateTo(this.url)
-
-    if (!actor.hasMemoryOf('isAuthenticated')) {
-      await actor.attemptsTo(AuthenticateWith.theTestUser())
-      actor.remembers('isAuthenticated', true)
-    }
+    await actor.attemptsTo(AuthenticateWith.theTestUser())
+    actor.remembers('isAuthenticated', true)
   }
 }

--- a/test/features/submit.notification.real.defra.id.feature
+++ b/test/features/submit.notification.real.defra.id.feature
@@ -1,0 +1,7 @@
+@real-defra-id
+Feature: Submits a full exemption notification in environments integrated with real Defra ID
+
+  Scenario: After successfully completing all the tasks on the task list, the user is able to submit their notification
+    Given the user has completed all the tasks on the task list and is on the Check your answers page
+    When the user clicks Confirm and send
+    Then the confirmation page is displayed with an application reference


### PR DESCRIPTION
## Description

This pull request introduces the capability to run a smoke test suite against a test environment that is integrated with the real DEFRA ID service.

Previously, all automated tests were executed against a development environment that used a stubbed version of DEFRA ID. This allowed tests to dynamically create and tear down users for each scenario. To enable testing on more realistic, integrated environments, this change implements an environment-aware authentication strategy.

When the `ENVIRONMENT` variable is set to `test`, the framework will:

- Use a single, pre-existing permanent user account to authenticate.
- Bypass the test user creation and teardown steps.
- Target a specific suite of smoke tests tagged with `@real-defra-id`.

This was achieved by modifying the core test framework to handle different authentication flows and test configurations based on the target environment.

## Checklist

Before submitting the PR, ensure the following:

- [x] I have run all tests locally and confirmed they pass.
- [x] I have added tests that cover new functionality or changes (if applicable).
- [x] I have updated the documentation, including README.md and/or other relevant files.

## Related Tickets/Issues

- Link to relevant Jira tickets or GitHub issues, if applicable.

## Changes

- [x] Feature/Scenario(s) added
- [ ] Steps definitions added/modified.
- [x] Core framework changes

## Notes to Reviewers

This PR establishes the foundational pattern for testing against environments with a real, persistent login service.

To run the new smoke test locally against the test environment, you will need to:

1.  Set the required environment variables in your shell:
    ```bash
    export ENVIRONMENT=test
    export DEFRA_ID_USER_PASSWORD=<your_password>
    ```
2.  Temporarily update the `baseUrl` in `wdio.local.conf.js` to point to the test environment:
    ```javascript
    // in wdio.local.conf.js
    baseUrl: 'https://marine-licensing-frontend.test.cdp-int.defra.cloud/',
    ```
3.  Run the tests using the specific tag:
    ```bash
    npm run test:parallel:local -- --cucumberOpts.tags "@real-defra-id"
    ```

The `wdio.conf.js` has been updated to automatically select the `@real-defra-id` tag when `ENVIRONMENT=test`, but for local runs, the tag must be specified on the command line as shown above.

## Screenshots (if applicable)

- N/A
