### PR TITLE
Use cdp https proxy to fix defra id issues in test

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -4,11 +4,15 @@ import {
   logUserCleanup
 } from './test-infrastructure/capture/index.js'
 
-const chromeProxyConfig = {
-  proxy: {
-    proxyType: 'manual',
-    httpProxy: 'localhost:3128',
-    sslProxy: 'localhost:3128'
+let chromeProxyConfig = {}
+if (process.env.CDP_HTTPS_PROXY) {
+  const url = new URL(process.env.CDP_HTTPS_PROXY)
+  chromeProxyConfig = {
+    proxy: {
+      proxyType: 'manual',
+      httpProxy: `${url.host}:${url.port}`,
+      sslProxy: `${url.host}:${url.port}`
+    }
   }
 }
 


### PR DESCRIPTION
Use cdp https proxy to fix defra id issues in test