### PR TITLE
introduce proxy settings for playwright

### DIFF
--- a/test-infrastructure/screenplay/abilities/browse.d365.js
+++ b/test-infrastructure/screenplay/abilities/browse.d365.js
@@ -25,9 +25,19 @@ export default class BrowseD365 {
       }
 
       this.browser = await chromium.launch(launchOptions)
-      this.context = await this.browser.newContext({
+
+      const contextOptions = {
         ignoreHTTPSErrors: true
-      })
+      }
+
+      const proxyUrlConfig = process.env.HTTP_PROXY
+      if (proxyUrlConfig) {
+        contextOptions.proxy = {
+          server: proxyUrlConfig
+        }
+      }
+
+      this.context = await this.browser.newContext(contextOptions)
 
       this.context.setDefaultTimeout(60000)
       this.context.setDefaultNavigationTimeout(60000)


### PR DESCRIPTION
## Description

- Added HTTP proxy support to the Playwright-based D365 browser ability to ensure consistent proxy configuration across all test components.
- Fixed missing proxy configuration that was causing connectivity issues in environments requiring HTTP proxy settings.
- Aligned `browse.d365.js` with existing proxy patterns used in `login.to.d365.js` and `wdio.conf.js`.

## Checklist

Before submitting the PR, ensure the following:

- [ ] I have run all tests locally and confirmed they pass.
- [ ] I have added tests that cover new functionality or changes (if applicable).
- [ ] I have updated the documentation, including README.md and/or other relevant files.

## Related Tickets/Issues

- Related to D365 test connectivity issues in proxy-enabled environments

## Changes

- [ ] Feature/Scenario(s) added
- [ ] Steps definitions added/modified.
- [x] Core framework changes

## Notes to Reviewers

- This change adds proxy configuration support to the Playwright browser context in `BrowseD365` ability
- The implementation follows the same pattern as other proxy configurations in the codebase:
  - Checks for `HTTP_PROXY` environment variable
  - Only applies proxy settings when the environment variable is present
  - Uses Playwright's standard proxy configuration format
- **Testing Requirements**: To test this change, set the `HTTP_PROXY` environment variable and run D365 tests to ensure they connect properly through the proxy

## Technical Details

### Files Changed

- `test-infrastructure/screenplay/abilities/browse.d365.js`

### Implementation

```javascript
const contextOptions = {
  ignoreHTTPSErrors: true
}

const proxyUrlConfig = process.env.HTTP_PROXY
if (proxyUrlConfig) {
  contextOptions.proxy = {
    server: proxyUrlConfig
  }
}

this.context = await this.browser.newContext(contextOptions)
```

### Consistency with Existing Code

- `login.to.d365.js`: Uses `HTTP_PROXY` with `ProxyAgent` for fetch requests
- `wdio.conf.js`: Configures Chrome proxy via `chromeProxyConfig`
- `browse.d365.js`: Now uses `HTTP_PROXY` for Playwright browser context

This ensures all three components (authentication, WebDriver tests, and D365 browsing) work consistently in proxy environments.

## Screenshots (if applicable)

Not applicable - this is an infrastructure/configuration change with no UI impact.
