### PR TITLE
Switch docker image to use official microsoft playwright image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 COPY . .
-RUN npm install
+RUN npm install \
+    && npx playwright install
 
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
-FROM node:22.13.1-alpine
+
+FROM mcr.microsoft.com/playwright:v1.54.0-noble
 
 ENV TZ="Europe/London"
-ENV PLAYWRIGHT_BROWSERS_PATH=/usr
-ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/lib/chromium/chromium
 ENV HEADLESS=true
 
 USER root
 
-RUN apk add --no-cache \
-    openjdk17-jre-headless \
+RUN apt-get update && apt-get install -y \
+    openjdk-17-jre-headless \
     curl \
-    aws-cli \
-    chromium \
-    nss \
-    freetype \
-    harfbuzz \
-    ca-certificates \
-    ttf-freefont
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/test-infrastructure/screenplay/abilities/browse.d365.js
+++ b/test-infrastructure/screenplay/abilities/browse.d365.js
@@ -50,10 +50,6 @@ export default class BrowseD365 {
         ]
       }
 
-      if (process.env.ENVIRONMENT === 'test') {
-        launchOptions.executablePath = '/usr/lib/chromium/chromium'
-      }
-
       this.browser = await chromium.launch(launchOptions)
 
       const contextOptions = {


### PR DESCRIPTION
Switch docker image to use official microsoft playwright image

Reason: alpine is not compatible with the binaries that playwright installs