### PR TITLE
Ml 576 a11y check radio

### DIFF
--- a/test-infrastructure/screenplay/interactions/ensure.dashboard.displays.notification.js
+++ b/test-infrastructure/screenplay/interactions/ensure.dashboard.displays.notification.js
@@ -35,7 +35,7 @@ export default class EnsureDashboardDisplaysNotification extends Task {
     )
 
     const today = new Date().toLocaleDateString('en-GB', {
-      day: '2-digit',
+      day: 'numeric',
       month: 'short',
       year: 'numeric'
     })

--- a/test-infrastructure/screenplay/interactions/ensure.page.accessibility.js
+++ b/test-infrastructure/screenplay/interactions/ensure.page.accessibility.js
@@ -11,6 +11,8 @@ export default class EnsurePageAccessibility extends Task {
 
   async performAs() {
     const builder = new AxeBuilder({ client: browser })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .exclude('input[type="radio"][aria-expanded]')
     const result = await builder.analyze()
     const hasViolations = result.violations.length > 0
     if (hasViolations) {


### PR DESCRIPTION
## Description

- gov.uk radio button with conditional reveal, uses aria-expanded which fails an Axe a11y check. [Noted in Defra guidance](https://defra-design.github.io/accessibility/resources/content/checklist-of-common-accessibility-errors-found-in-new-services/#invalid-aria-expanded-error) Axe aren't going to change this, as it's not an officially supported attribute on radio buttons. Gov.uk also are not going to fix it - https://github.com/alphagov/govuk-frontend/issues/979. So the only options are to not use the pattern, or to exempt it from the Axe checks - this change does the latter.
- update dashboard notification test to look for single digit day rather than 2 digit

## Checklist

Before submitting the PR, ensure the following:

- [x] I have run all tests locally and confirmed they pass.
- [ ] I have added tests that cover new functionality or changes (if applicable).
- [ ] I have updated the documentation, including README.md and/or other relevant files.

## Related Tickets/Issues

- [Link to relevant Jira tickets or GitHub issues, if applicable.](https://eaflood.atlassian.net/browse/ML-576)

## Changes

- [ ] Feature/Scenario(s) added
- [ ] Steps definitions added/modified.
- [ ] Core framework changes

## Notes to Reviewers

- Share any specific context reviewers should know.
- If testing the PR requires setup, outline instructions clearly.

## Screenshots (if applicable)

- Include screenshots for UI changes or critical scenarios.
