### PR TITLE
Remove --single-file switch from allure report generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:gherkin": "node bin/gherkin-standards-validation/index.js",
     "postinstall": "npm run setup:husky",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
-    "report": "allure generate allure-results --single-file --clean",
+    "report": "allure generate allure-results --clean",
     "report:publish": "npm run report; ./bin/publish-tests.sh",
     "knip": "knip"
   },


### PR DESCRIPTION
The allure reports are reaching 0.5GB in size due to the `--single-file` switch being used.  All the screenshots are encoded as base64 and embedded into the file.

Removed this switch so that the images are only loaded on demand.