### PR TITLE
Change coordinate assertion strategy for file upload - visible coordinates are no longer displayed on Site Details Review

### DIFF
--- a/test-infrastructure/pages/review.site.details.page.js
+++ b/test-infrastructure/pages/review.site.details.page.js
@@ -30,6 +30,7 @@ export default class ReviewSiteDetailsPage extends CommonElementsPage {
     '//dt[contains(text(), "File uploaded")]/following-sibling::dd'
   static extractedCoordinatesValue =
     '//dt[contains(text(), "Extracted")]/following-sibling::dd'
+  static siteDetailsDataScript = '#site-details-data'
   static startAndEndPointsValue =
     '//dt[contains(text(), "Start and end points")]/following-sibling::dd'
   static point2Value = '//dt[contains(text(), "Point 2")]/following-sibling::dd'


### PR DESCRIPTION
# Adapt File Upload Coordinate Assertions for Hidden UI Elements

## Description

- Adapted coordinate verification tests to work with extracted coordinates being present in DOM but not visibly displayed
- Updated assertions to extract coordinate data from script elements instead of visible text elements

## Checklist

- [x] I have run all tests locally and confirmed they pass.
- [ ] I have added tests that cover new functionality or changes (if applicable).
- [ ] I have updated the documentation, including README.md and/or other relevant files.

## Related Tickets/Issues

- ML-68: Removing coordinates file upload SD review

## Changes

- [ ] Feature/Scenario(s) added
- [ ] Steps definitions added/modified.
- [x] Core framework changes

## Notes to Reviewers

- Tests now extract coordinates from `#site-details-data` script element in DOM
- Maintains full test coverage for both KML and Shapefile uploads
- Simplified overengineered extraction logic and resolved linting issues
- All existing test scenarios continue to pass without modification

## Test Report

<img width="810" height="899" alt="image" src="https://github.com/user-attachments/assets/cd734e48-ccd4-431d-b42f-007487bf8524" />
