### PR TITLE
ML-139 - Fix text match on coordinates system in site details

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm install
 # Local development (requires locally running services)
 npm run test:local
 npm run test:local:debug
+npm run test:local:headless
 
 # Smoke testing - Run core user journey tests quickly
 npm run test:local -- --cucumberOpts.tags "@smoke"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "npm run clean && wdio run wdio.conf.js",
     "test:browserstack": "npm run clean && wdio run wdio.browserstack.conf.js",
     "test:local": "npm run clean && wdio run wdio.local.conf.js",
+    "test:local:headless": "npm run clean && HEADLESS=true wdio run wdio.local.conf.js",
     "test:local:debug": "npm run clean && DEBUG=true wdio run wdio.local.conf.js",
     "test:github": "npm run clean && wdio run wdio.github.conf.js",
     "test:github:browserstack": "npm run clean && wdio run wdio.github.browserstack.conf.js",

--- a/test-infrastructure/screenplay/interactions/ensure.check.your.answers.page.js
+++ b/test-infrastructure/screenplay/interactions/ensure.check.your.answers.page.js
@@ -144,7 +144,7 @@ export default class EnsureCheckYourAnswersPage extends Task {
         CheckYourAnswersPage.locators.siteDetails.coordinateSystemValue
       )
 
-      if (actualText.trim() !== expectedDisplayText) {
+      if (actualText.trim().replaceAll('\n', ' ') !== expectedDisplayText) {
         expect.fail(
           `Coordinate system mismatch. Expected: "${expectedDisplayText}", but found: "${actualText}"`
         )


### PR DESCRIPTION
## Description

- The coordinate system text on site details includes a `<br>` which wdio's getText converts to a line break. This change removes that line break before matching against the expected text
- also, have added a NPM task to run the local tests in a headless browser

## Checklist

Before submitting the PR, ensure the following:

- [x] I have run all tests locally and confirmed they pass.
- [ ] I have added tests that cover new functionality or changes (if applicable).
- [ ] I have updated the documentation, including README.md and/or other relevant files.

## Related Tickets/Issues

https://eaflood.atlassian.net/browse/ML-139

## Changes

- [ ] Feature/Scenario(s) added
- [x] Steps definitions added/modified.
- [ ] Core framework changes

## Notes to Reviewers

- Share any specific context reviewers should know.
- If testing the PR requires setup, outline instructions clearly.

## Screenshots (if applicable)

- Include screenshots for UI changes or critical scenarios.
