### PR TITLE
ML-518: Accept or reject cookies from the banner page

### DIFF
--- a/test-infrastructure/screenplay/interactions/accept.cookies.from.banner.js
+++ b/test-infrastructure/screenplay/interactions/accept.cookies.from.banner.js
@@ -1,0 +1,14 @@
+import CookieBannerPage from '~/test-infrastructure/pages/cookie.banner.page.js'
+import Task from '../base/task.js'
+
+export default class AcceptCookiesFromBanner extends Task {
+  static now() {
+    return new AcceptCookiesFromBanner()
+  }
+
+  async performAs(actor) {
+    const browseTheWeb = actor.ability
+    await browseTheWeb.click(CookieBannerPage.locators.acceptAnalyticsButton)
+    actor.remembers('cookiePreferencesSet', true)
+  }
+}

--- a/test-infrastructure/screenplay/interactions/index.js
+++ b/test-infrastructure/screenplay/interactions/index.js
@@ -1,4 +1,5 @@
 export * from '../page-interactions'
+export { default as AcceptCookiesFromBanner } from './accept.cookies.from.banner'
 export { default as ClickAddAnotherPoint } from './button-interactions/click.add.another.point'
 export { default as ClickButton } from './button-interactions/click.button'
 export { default as ClickCancel } from './button-interactions/click.cancel'
@@ -44,6 +45,7 @@ export { default as EnsureThatIatIsDisplayed } from './ensure.that.iat.is.displa
 export { default as EnsureThatTheExemptionDetailsAreCorrect } from './ensure.that.the.exemption.details.are.correct'
 export { default as EnsureViewDetailsPage } from './ensure.view.details.page'
 export { default as HandleCookieBanner } from './handle.cookie.banner'
+export { default as RejectCookiesFromBanner } from './reject.cookies.from.banner'
 export { default as RememberTheExemptionReferenceNumber } from './remember.the.exemption.reference.number'
 export { default as SaveCookiePreferences } from './save.cookie.preferences'
 export { default as SelectTheTask } from './select.task'

--- a/test-infrastructure/screenplay/interactions/reject.cookies.from.banner.js
+++ b/test-infrastructure/screenplay/interactions/reject.cookies.from.banner.js
@@ -1,0 +1,14 @@
+import CookieBannerPage from '~/test-infrastructure/pages/cookie.banner.page.js'
+import Task from '../base/task.js'
+
+export default class RejectCookiesFromBanner extends Task {
+  static now() {
+    return new RejectCookiesFromBanner()
+  }
+
+  async performAs(actor) {
+    const browseTheWeb = actor.ability
+    await browseTheWeb.click(CookieBannerPage.locators.rejectAnalyticsButton)
+    actor.remembers('cookiePreferencesSet', true)
+  }
+}

--- a/test/features/cookies.feature
+++ b/test/features/cookies.feature
@@ -15,6 +15,18 @@ Feature: Cookies policy page allows users to manage cookie preferences
     When the cookies link is clicked in the footer
     Then the "No" radio button is selected for analytics cookies
 
+  @new
+  Scenario: Analytics cookies accepted from the cookie banner
+    Given the project name page is displayed with the cookie banner visible
+    When the analytics cookies are accepted from the cookie banner
+    Then the analytics cookies are enabled
+
+  @new
+  Scenario: Analytics cookies rejected from the cookie banner
+    Given the project name page is displayed with the cookie banner visible
+    When the analytics cookies are rejected from the cookie banner
+    Then the analytics cookies are disabled
+
   @smoke
   Scenario: Accepting analytics cookies
     Given a user is on the cookies policy page
@@ -50,4 +62,3 @@ Feature: Cookies policy page allows users to manage cookie preferences
     When returning to the cookies policy page
     And selecting No for analytics cookies and saving preferences
     Then the analytics cookies are disabled
-    

--- a/test/steps/cookies.steps.js
+++ b/test/steps/cookies.steps.js
@@ -1,6 +1,7 @@
 import { Given, Then, When } from '@cucumber/cucumber'
 import { browser } from '@wdio/globals'
 import {
+  AcceptCookiesFromBanner,
   Actor,
   ApplyForExemption,
   BrowseTheWeb,
@@ -10,6 +11,7 @@ import {
   EnsureCookiesPolicyPage,
   EnsureCookiesRadioButtonSelected,
   Navigate,
+  RejectCookiesFromBanner,
   SaveCookiePreferences
 } from '~/test-infrastructure/screenplay'
 
@@ -99,3 +101,27 @@ When('returning to the cookies policy page', async function () {
   await this.actor.attemptsTo(ClickCookiesLink.now())
   await this.actor.attemptsTo(EnsureCookiesPolicyPage.isDisplayed())
 })
+
+When(
+  'the analytics cookies are accepted from the cookie banner',
+  async function () {
+    await this.actor.attemptsTo(AcceptCookiesFromBanner.now())
+  }
+)
+
+When(
+  'the analytics cookies are rejected from the cookie banner',
+  async function () {
+    await this.actor.attemptsTo(RejectCookiesFromBanner.now())
+  }
+)
+
+Given(
+  'the project name page is displayed with the cookie banner visible',
+  async function () {
+    this.actor = new Actor('Alice')
+    this.actor.can(new BrowseTheWeb(browser))
+    this.actor.intendsTo(ApplyForExemption.withNoPreviousCookieDecision())
+    await this.actor.attemptsTo(Navigate.toTheMarineLicensingApp())
+  }
+)


### PR DESCRIPTION
## Description

- new test scenarios to cover accepting or rejecting cookies from the banner

## Changes

- [X] Feature/Scenario(s) added
- [X] Steps definitions added/modified.
- [X] Core framework changes
