### PR TITLE
ML-1192: Site details tests

### DIFF
--- a/.claude/commands/lcml-test.md
+++ b/.claude/commands/lcml-test.md
@@ -15,9 +15,10 @@ You are an automation engineer writing Playwright + Cucumber BDD journey tests f
 ## Key Principles
 
 1. **Reuse over duplication**: Always check existing steps first. Generic steps like `the user clicks Continue`, `the user selects {string}` work across all pages.
-2. **Journey flow focus**: Test that the user can navigate through pages and complete tasks. Do NOT test error validations, field-level validation, or error messages.
-3. **Consolidate scenarios**: If multiple ACs describe a sequential flow through pages, consolidate them into a single scenario rather than one-per-page.
-4. **No page furniture assertions**: Do not assert on standard GOV.UK elements (Continue/Cancel/Back links, error summaries) — these are consistent across all pages and tested elsewhere.
+2. **Reuse exemption helpers**: LCML and exemption journeys share many pages (site details, file upload, choose file type). Import existing page action helpers from `test/support/site-details-flow.js` instead of duplicating selectors. Examples: `selectFileType`, `uploadFile`, `selectProvideMethod`, `selectMoreThanOneSite`, `enterActivityDates`, `enterActivityDescription`. Only the navigation TO the page differs between LCML and exemptions; the page actions themselves are identical.
+3. **Journey flow focus**: Test that the user can navigate through pages and complete tasks. Do NOT test error validations, field-level validation, or error messages.
+4. **Consolidate scenarios**: If multiple ACs describe a sequential flow through pages, consolidate them into a single scenario rather than one-per-page.
+5. **No page furniture assertions**: Do not assert on standard GOV.UK elements (Continue/Cancel/Back links, error summaries) — these are consistent across all pages and tested elsewhere.
 
 ## Project Structure
 
@@ -64,17 +65,37 @@ Task list → "Site details" link
 
 ## Existing Helper Functions
 
-### `loginAndStartApplication(world, role)` — in lcml.apply.steps.js
+### LCML helpers — `test/support/lcml-helpers.js`
 
-Registers user → login → accept cookies → confirm user type (if on confirm page) → click "Apply for a marine licence" → enter project name → lands on task list.
+- `loginAndStartApplication(world, role)` — registers user → login → accept cookies → confirm user type → click "Apply for a marine licence" → enter project name → lands on task list. `role` = `'organisation' | 'intermediary' | 'individual'`
+- `completeSpecialLegalPowers(page, answer)` — clicks "Special legal powers" → selects Yes/No → fills details if Yes → saves → verifies "Completed" status. `answer` = `'Yes' | 'No'`
+- `completeOtherAuthorities(page, answer)` — clicks "Other authorities" → selects Yes/No → fills details if Yes → saves. `answer` = `'Yes' | 'No'`
 
-### `loginAndReachTaskList(world)` — in lcml.site.details.steps.js
+### Exemption page actions — `test/support/site-details-flow.js`
 
-Same as above but hardcoded to `employee` user type. Also completes special legal powers if present.
+These work for **both** exemption and LCML journeys because the pages share the same selectors. Reuse them instead of writing your own:
 
-### `completeSpecialLegalPowers(page, answer)` — in lcml.apply.steps.js
+**Generic page actions:**
+- `continueFromBeforeYouStart(page)` — clicks `a.govuk-button` (Continue link on intro page)
+- `selectProvideMethod(page, 'enter-manually' | 'file-upload')` — clicks `#coordinatesType` or `#coordinatesType-2`
+- `selectMoreThanOneSite(page, true | false)` — clicks `#multipleSitesEnabled` or `#multipleSitesEnabled-2`
+- `enterActivityDates(page, dates)` — fills date inputs
+- `enterActivityDescription(page, description)` — fills `#activityDescription`
+- `enterSiteName(page, name)` — fills `#siteName`
 
-Clicks "Special legal powers" → selects Yes/No → saves → verifies "Completed" status.
+**File upload page actions:**
+- `selectFileType(page, 'KML' | 'Shapefile')` — clicks `#fileUploadType` or `#fileUploadType-2`
+- `uploadFile(page, relativePath)` — sets file on `input[type="file"]` (works on hidden `#file-id-input` too)
+
+**Coordinate entry actions:**
+- `selectCoordinatesEntryMethod(page, 'circle' | 'polygon')`
+- `selectCoordinateSystem(page, 'WGS84' | 'OSGB36')`
+- `enterCentrePointWGS84(page, lat, lng)` / `enterCentrePointOSGB36(page, eastings, northings)`
+- `enterPolygonCoordinatesWGS84(page, coordinates[])` / `enterPolygonCoordinatesOSGB36(page, coordinates[])`
+- `enterWidth(page, width)`
+
+**Full flow orchestrators (for exemption tests, can be referenced for LCML patterns):**
+- `completeSiteDetailsFlow(page, siteDetails)` — dispatcher that routes to single/multi-site, manual/file-upload flows based on `siteDetails.coordinatesEntryMethod` and `siteDetails.multipleSitesEnabled`
 
 ## Existing Step Definitions
 
@@ -118,13 +139,41 @@ Clicks "Special legal powers" → selects Yes/No → saves → verifies "Complet
 ### From acceptance criteria — focus on journey flow:
 
 1. **Read** existing LCML features and steps — check for reusable steps FIRST
-2. **Filter ACs**: Skip validation/error ACs. Focus on ACs that describe navigation, task completion, data saving, and page display
-3. **Consolidate**: If multiple ACs describe a sequential page flow, write ONE scenario that covers the whole flow rather than one scenario per AC
-4. **Reuse generic steps**: Steps like `the user clicks Continue`, `the user selects {string}` are generic — use them across pages. Only create new steps for page-specific assertions (e.g. heading + project name checks)
-5. **Discover selectors** if testing new pages: use Playwright MCP or Playwright scripts
-6. **Write** the feature file in `test/features/lcml.<name>.feature` with `@lcml` tag
-7. **Write** step definitions — add to existing step files where possible. Only create new files for distinct journey areas
-8. **Run** to verify: `npx cucumber-js --config cucumber.mjs --profile lcml --name "<scenario>" --format summary`
+2. **Check `test/support/site-details-flow.js`** for exemption page action helpers — most pages (file upload, choose file type, coordinate entry) are shared between LCML and exemptions and the helpers can be imported and reused
+3. **Filter ACs**: Skip validation/error ACs. Focus on ACs that describe navigation, task completion, data saving, and page display
+4. **Consolidate**: If multiple ACs describe a sequential page flow, write ONE scenario that covers the whole flow rather than one scenario per AC
+5. **Reuse generic steps**: Steps like `the user clicks Continue`, `the user selects {string}` are generic — use them across pages. Only create new steps for page-specific assertions (e.g. heading + project name checks)
+6. **Discover selectors** if testing new pages: use Playwright MCP or Playwright scripts
+7. **Write** the feature file in `test/features/lcml.<name>.feature` with `@lcml` tag
+8. **Write** step definitions — add to existing step files where possible. Only create new files for distinct journey areas
+9. **Run** to verify: `npx cucumber-js --config cucumber.mjs --profile lcml --name "<scenario>" --format summary`
+
+### Reusing exemption page actions in LCML steps
+
+The pages from "How do you want to provide the coordinates" onwards are shared between LCML and exemption journeys. Import the helpers from `site-details-flow.js`:
+
+```javascript
+import {
+  selectFileType,
+  uploadFile,
+  selectProvideMethod,
+  selectMoreThanOneSite,
+  enterActivityDates,
+  enterActivityDescription
+} from '../support/site-details-flow.js'
+
+// LCML step that uses shared page actions
+When(
+  'the user uploads a valid {string} file',
+  async function (fileType) {
+    await selectFileType(this.page, fileType)
+    await uploadFile(this.page, SAMPLE_FILES[fileType])
+    await this.page.waitForLoadState('load')
+  }
+)
+```
+
+The only LCML-specific code should be the navigation TO the page (via `loginAndStartApplication` + LCML task list links). Once on a shared page, use the exemption helpers.
 
 ### Step definition patterns:
 

--- a/.claude/commands/lcml-test.md
+++ b/.claude/commands/lcml-test.md
@@ -76,6 +76,7 @@ Task list → "Site details" link
 These work for **both** exemption and LCML journeys because the pages share the same selectors. Reuse them instead of writing your own:
 
 **Generic page actions:**
+
 - `continueFromBeforeYouStart(page)` — clicks `a.govuk-button` (Continue link on intro page)
 - `selectProvideMethod(page, 'enter-manually' | 'file-upload')` — clicks `#coordinatesType` or `#coordinatesType-2`
 - `selectMoreThanOneSite(page, true | false)` — clicks `#multipleSitesEnabled` or `#multipleSitesEnabled-2`
@@ -84,10 +85,12 @@ These work for **both** exemption and LCML journeys because the pages share the 
 - `enterSiteName(page, name)` — fills `#siteName`
 
 **File upload page actions:**
+
 - `selectFileType(page, 'KML' | 'Shapefile')` — clicks `#fileUploadType` or `#fileUploadType-2`
 - `uploadFile(page, relativePath)` — sets file on `input[type="file"]` (works on hidden `#file-id-input` too)
 
 **Coordinate entry actions:**
+
 - `selectCoordinatesEntryMethod(page, 'circle' | 'polygon')`
 - `selectCoordinateSystem(page, 'WGS84' | 'OSGB36')`
 - `enterCentrePointWGS84(page, lat, lng)` / `enterCentrePointOSGB36(page, eastings, northings)`
@@ -95,6 +98,7 @@ These work for **both** exemption and LCML journeys because the pages share the 
 - `enterWidth(page, width)`
 
 **Full flow orchestrators (for exemption tests, can be referenced for LCML patterns):**
+
 - `completeSiteDetailsFlow(page, siteDetails)` — dispatcher that routes to single/multi-site, manual/file-upload flows based on `siteDetails.coordinatesEntryMethod` and `siteDetails.multipleSitesEnabled`
 
 ## Existing Step Definitions
@@ -163,14 +167,11 @@ import {
 } from '../support/site-details-flow.js'
 
 // LCML step that uses shared page actions
-When(
-  'the user uploads a valid {string} file',
-  async function (fileType) {
-    await selectFileType(this.page, fileType)
-    await uploadFile(this.page, SAMPLE_FILES[fileType])
-    await this.page.waitForLoadState('load')
-  }
-)
+When('the user uploads a valid {string} file', async function (fileType) {
+  await selectFileType(this.page, fileType)
+  await uploadFile(this.page, SAMPLE_FILES[fileType])
+  await this.page.waitForLoadState('load')
+})
 ```
 
 The only LCML-specific code should be the navigation TO the page (via `loginAndStartApplication` + LCML task list links). Once on a shared page, use the exemption helpers.

--- a/test/features/lcml.apply.for.marine.licence.feature
+++ b/test/features/lcml.apply.for.marine.licence.feature
@@ -4,20 +4,20 @@ Feature: LCML: Apply for a marine licence
   I want to apply for a marine licence
   So that I can carry out licensable marine activities
 
-  Scenario: Organisation user can submit with other authorities answered Yes
-    Given an organisation user has completed other permissions with special legal powers "Yes" and other authorities "Yes"
+  Scenario: Organisation user can submit a marine licence with KML site upload and other authorities Yes
+    Given an organisation user has completed all tasks with special legal powers "Yes" and other authorities "Yes"
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
 
-  Scenario: Intermediary user can submit with other authorities answered No
-    Given an intermediary user has completed other permissions with special legal powers "No" and other authorities "No"
+  Scenario: Intermediary user can submit a marine licence with shapefile site upload and other authorities No
+    Given an intermediary user has completed all tasks with special legal powers "No" and other authorities "No"
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
 
-  Scenario: Individual user can submit with other authorities answered No
-    Given an individual user has completed other permissions with other authorities "No"
+  Scenario: Individual user can submit a marine licence with KML site upload and other authorities No
+    Given an individual user has completed all tasks with other authorities "No"
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page

--- a/test/features/lcml.site.details.feature
+++ b/test/features/lcml.site.details.feature
@@ -8,3 +8,18 @@ Feature: LCML: Site details journey
     Given an organisation user is on the site details page
     When the user navigates through site details to the choose file type page
     Then the choose file type page heading and project name are displayed
+
+  Scenario Outline: Uploading a file lands on the review site details page
+    Given an organisation user is on the upload file page for "<fileType>"
+    When the user uploads a valid "<fileType>" file and saves
+    Then the review site details page is displayed for the uploaded site
+
+    Examples:
+      | fileType  |
+      | KML       |
+      | Shapefile |
+
+  Scenario: Continue from review saves site details as In Progress and re-enters via task list
+    Given an organisation user has uploaded a valid "KML" file and is on the review site details page
+    When the user continues to the task list and re-enters the site details task
+    Then the review site details page is displayed for the uploaded site

--- a/test/steps/dashboard.filter.steps.js
+++ b/test/steps/dashboard.filter.steps.js
@@ -181,6 +181,7 @@ Then('the case status in D365 matches', async function (dataTable) {
 
   // Launch a separate browser for D365
   const { browser: d365Browser, page: d365Page } = await launchD365Browser()
+  let appPage
 
   try {
     await loginToD365(d365Page)
@@ -195,7 +196,7 @@ Then('the case status in D365 matches', async function (dataTable) {
     )
 
     // Open Application URL in a new tab within the D365 browser context
-    const appPage = await d365Page.context().newPage()
+    appPage = await d365Page.context().newPage()
     await appPage.goto(applicationUrl, { waitUntil: 'load' })
 
     const expectedStatus = expectedDetails['Application Status']
@@ -211,6 +212,19 @@ Then('the case status in D365 matches', async function (dataTable) {
       format(new Date(), 'd MMMM yyyy'),
       { timeout: 30_000 }
     )
+  } catch (err) {
+  
+    if (d365Page && !d365Page.isClosed()) {
+      const screenshot = await d365Page.screenshot({ fullPage: true })
+      this.attach(screenshot, 'image/png')
+      this.attach(`D365 failure URL: ${d365Page.url()}`, 'text/plain')
+    }
+    if (appPage && !appPage.isClosed()) {
+      const appScreenshot = await appPage.screenshot({ fullPage: true })
+      this.attach(appScreenshot, 'image/png')
+      this.attach(`D365 application page URL: ${appPage.url()}`, 'text/plain')
+    }
+    throw err
   } finally {
     await d365Browser.close()
   }

--- a/test/steps/dashboard.filter.steps.js
+++ b/test/steps/dashboard.filter.steps.js
@@ -213,7 +213,6 @@ Then('the case status in D365 matches', async function (dataTable) {
       { timeout: 30_000 }
     )
   } catch (err) {
-  
     if (d365Page && !d365Page.isClosed()) {
       const screenshot = await d365Page.screenshot({ fullPage: true })
       this.attach(screenshot, 'image/png')

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -3,31 +3,35 @@ import { expect } from '@playwright/test'
 import {
   loginAndStartApplication,
   completeSpecialLegalPowers,
-  completeOtherAuthorities
+  completeOtherAuthorities,
+  completeSiteDetailsViaFileUpload
 } from '../support/lcml-helpers.js'
 
 Given(
-  'an organisation user has completed other permissions with special legal powers {string} and other authorities {string}',
+  'an organisation user has completed all tasks with special legal powers {string} and other authorities {string}',
   async function (slpAnswer, oaAnswer) {
     await loginAndStartApplication(this, 'organisation')
+    await completeSiteDetailsViaFileUpload(this, 'KML')
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
   }
 )
 
 Given(
-  'an intermediary user has completed other permissions with special legal powers {string} and other authorities {string}',
+  'an intermediary user has completed all tasks with special legal powers {string} and other authorities {string}',
   async function (slpAnswer, oaAnswer) {
     await loginAndStartApplication(this, 'intermediary')
+    await completeSiteDetailsViaFileUpload(this, 'Shapefile')
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
   }
 )
 
 Given(
-  'an individual user has completed other permissions with other authorities {string}',
+  'an individual user has completed all tasks with other authorities {string}',
   async function (oaAnswer) {
     await loginAndStartApplication(this, 'individual')
+    await completeSiteDetailsViaFileUpload(this, 'KML')
     await completeOtherAuthorities(this.page, oaAnswer)
   }
 )

--- a/test/steps/lcml.site.details.steps.js
+++ b/test/steps/lcml.site.details.steps.js
@@ -59,15 +59,12 @@ When(
 When(
   'the user continues to the task list and re-enters the site details task',
   async function () {
-   
     await this.page.locator('button:has-text("Continue")').click()
     await this.page.waitForLoadState('load')
 
-    
     const taskList = new TaskListPage(this.page)
     await taskList.expectTaskStatus('Site details', 'In Progress')
 
-    
     await taskList.selectTask('Site details')
     await this.page.waitForLoadState('load')
   }
@@ -96,12 +93,12 @@ Then(
     await expect(
       this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
     ).toContainText(this.data.projectName, { timeout: 30_000 })
-    
+
     await expect(this.page.locator('#site-location-card')).toContainText(
       'File uploaded',
       { timeout: 30_000 }
     )
-   
+
     const site1Card = this.page.locator('#site-details-1')
     await expect(site1Card).toBeVisible({ timeout: 30_000 })
     await expect(site1Card).toContainText('Incomplete')

--- a/test/steps/lcml.site.details.steps.js
+++ b/test/steps/lcml.site.details.steps.js
@@ -1,20 +1,37 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import {
-  loginAndStartApplication,
-  completeSpecialLegalPowers
+  loginAndReachTaskList,
+  loginAndNavigateToUploadPage,
+  uploadFileAndWaitForReviewPage
 } from '../support/lcml-helpers.js'
-
-async function loginAndReachTaskList(world) {
-  await loginAndStartApplication(world, 'organisation')
-  await completeSpecialLegalPowers(world.page, 'No')
-}
+import {
+  continueFromBeforeYouStart,
+  selectProvideMethod
+} from '../support/site-details-flow.js'
+import TaskListPage from '../pages/task.list.page.js'
 
 Given('an organisation user is on the site details page', async function () {
   await loginAndReachTaskList(this)
   await this.page.locator('a:has-text("Site details")').click()
   await this.page.waitForLoadState('load')
 })
+
+Given(
+  'an organisation user is on the upload file page for {string}',
+  async function (fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+  }
+)
+
+Given(
+  'an organisation user has uploaded a valid {string} file and is on the review site details page',
+  async function (fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+  }
+)
+
 
 When(
   'the user navigates through site details to the choose file type page',
@@ -26,12 +43,33 @@ When(
         timeout: 30_000
       }
     )
-    // Navigate to provide coordinates page
-    await this.page.locator('a.govuk-button:has-text("Continue")').click()
+    await continueFromBeforeYouStart(this.page)
     await this.page.waitForLoadState('load')
-    // Select file upload and continue
-    await this.page.locator('#coordinatesType').click()
+    await selectProvideMethod(this.page, 'file-upload')
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user uploads a valid {string} file and saves',
+  async function (fileType) {
+    await uploadFileAndWaitForReviewPage(this, fileType)
+  }
+)
+
+When(
+  'the user continues to the task list and re-enters the site details task',
+  async function () {
+    // Continue from review page → task list
     await this.page.locator('button:has-text("Continue")').click()
+    await this.page.waitForLoadState('load')
+
+    // Verify task is shown as In Progress on the task list (AC5)
+    const taskList = new TaskListPage(this.page)
+    await taskList.expectTaskStatus('Site details', 'In Progress')
+
+    // Re-enter the site details task (AC6)
+    await taskList.selectTask('Site details')
     await this.page.waitForLoadState('load')
   }
 )
@@ -48,3 +86,26 @@ Then(
     ).toContainText(this.data.projectName, { timeout: 30_000 })
   }
 )
+
+Then(
+  'the review site details page is displayed for the uploaded site',
+  async function () {
+    await expect(this.page.locator('h1').first()).toContainText(
+      'Review site details',
+      { timeout: 30_000 }
+    )
+    await expect(
+      this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+    // Providing the site location card
+    await expect(this.page.locator('#site-location-card')).toContainText(
+      'File uploaded',
+      { timeout: 30_000 }
+    )
+    // Site 1 card with Incomplete site name tag
+    const site1Card = this.page.locator('#site-details-1')
+    await expect(site1Card).toBeVisible({ timeout: 30_000 })
+    await expect(site1Card).toContainText('Incomplete')
+  }
+)
+

--- a/test/steps/lcml.site.details.steps.js
+++ b/test/steps/lcml.site.details.steps.js
@@ -32,7 +32,6 @@ Given(
   }
 )
 
-
 When(
   'the user navigates through site details to the choose file type page',
   async function () {
@@ -108,4 +107,3 @@ Then(
     await expect(site1Card).toContainText('Incomplete')
   }
 )
-

--- a/test/steps/lcml.site.details.steps.js
+++ b/test/steps/lcml.site.details.steps.js
@@ -59,15 +59,15 @@ When(
 When(
   'the user continues to the task list and re-enters the site details task',
   async function () {
-    // Continue from review page → task list
+   
     await this.page.locator('button:has-text("Continue")').click()
     await this.page.waitForLoadState('load')
 
-    // Verify task is shown as In Progress on the task list (AC5)
+    
     const taskList = new TaskListPage(this.page)
     await taskList.expectTaskStatus('Site details', 'In Progress')
 
-    // Re-enter the site details task (AC6)
+    
     await taskList.selectTask('Site details')
     await this.page.waitForLoadState('load')
   }
@@ -96,12 +96,12 @@ Then(
     await expect(
       this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
     ).toContainText(this.data.projectName, { timeout: 30_000 })
-    // Providing the site location card
+    
     await expect(this.page.locator('#site-location-card')).toContainText(
       'File uploaded',
       { timeout: 30_000 }
     )
-    // Site 1 card with Incomplete site name tag
+   
     const site1Card = this.page.locator('#site-details-1')
     await expect(site1Card).toBeVisible({ timeout: 30_000 })
     await expect(site1Card).toContainText('Incomplete')

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -2,6 +2,17 @@ import { expect } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 import { getConfig } from './config.js'
 import { registerTestUser, loginAsTestUser, acceptCookies } from './auth.js'
+import {
+  continueFromBeforeYouStart,
+  selectProvideMethod,
+  selectFileType,
+  uploadFile
+} from './site-details-flow.js'
+
+const SAMPLE_FILES = {
+  KML: 'test/resources/EXE_2025_00009-LOCATIONS.kml',
+  Shapefile: 'test/resources/valid-shapefile.zip'
+}
 
 const USER_TYPE_CONFIG = {
   organisation: {
@@ -96,4 +107,44 @@ export async function completeOtherAuthorities(page, answer) {
 
   await page.locator('button:has-text("Save and continue")').click()
   await page.waitForLoadState('load')
+}
+
+export async function loginAndReachTaskList(world, role = 'organisation') {
+  await loginAndStartApplication(world, role)
+  await completeSpecialLegalPowers(world.page, 'No')
+}
+
+export async function loginAndNavigateToUploadPage(world, fileType) {
+  await loginAndReachTaskList(world)
+  await navigateToUploadPage(world, fileType)
+}
+
+export async function navigateToUploadPage(world, fileType) {
+  await world.page.locator('a:has-text("Site details")').click()
+  await world.page.waitForLoadState('load')
+  await continueFromBeforeYouStart(world.page)
+  await world.page.waitForLoadState('load')
+  await selectProvideMethod(world.page, 'file-upload')
+  await world.page.waitForLoadState('load')
+  await selectFileType(world.page, fileType)
+  await world.page.waitForLoadState('load')
+}
+
+export async function uploadFileAndWaitForReviewPage(world, fileType) {
+  await uploadFile(world.page, SAMPLE_FILES[fileType])
+  await world.page.waitForLoadState('load')
+  // Spinner page redirects to review site details once upload completes
+  await world.page.waitForURL(
+    (url) => !url.toString().includes('upload-and-wait'),
+    { timeout: 60_000 }
+  )
+  await world.page.waitForLoadState('load')
+}
+
+export async function completeSiteDetailsViaFileUpload(world, fileType = 'KML') {
+  await navigateToUploadPage(world, fileType)
+  await uploadFileAndWaitForReviewPage(world, fileType)
+  // Continue from review page → back to task list
+  await world.page.locator('button:has-text("Continue")').click()
+  await world.page.waitForLoadState('load')
 }

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -141,7 +141,10 @@ export async function uploadFileAndWaitForReviewPage(world, fileType) {
   await world.page.waitForLoadState('load')
 }
 
-export async function completeSiteDetailsViaFileUpload(world, fileType = 'KML') {
+export async function completeSiteDetailsViaFileUpload(
+  world,
+  fileType = 'KML'
+) {
   await navigateToUploadPage(world, fileType)
   await uploadFileAndWaitForReviewPage(world, fileType)
   // Continue from review page → back to task list


### PR DESCRIPTION

1.  Add review site details scenarios after file upload (KML and Shapefile)
2. Add continue and re-enter scenario verifying In Progress task status
3. Update apply for marine licence scenarios to include site details upload
4. Capture D365 page screenshots on failure for easier debugging