### PR TITLE
increase timeout to make test suites pass consistently

### DIFF
--- a/test/steps/dashboard.filter.steps.js
+++ b/test/steps/dashboard.filter.steps.js
@@ -134,7 +134,7 @@ When('the user withdraws the submitted notification', async function () {
     this.data.completedExemptions[this.data.completedExemptions.length - 1]
 
   // Wait for D365 to finish processing the submission before withdrawing
-  await this.page.waitForTimeout(10_000)
+  await this.page.waitForTimeout(20_000)
 
   const dashboard = new DashboardPage(this.page)
   await dashboard.withdrawLink(latestExemption.projectName).click()
@@ -187,7 +187,7 @@ Then('the case status in D365 matches', async function (dataTable) {
     await loginToD365(d365Page)
     await verifyD365Login(d365Page)
     // Give D365 time to index the case before global search
-    await d365Page.waitForTimeout(10_000)
+    await d365Page.waitForTimeout(20_000)
     await searchD365Case(d365Page, latestExemption.applicationReference)
     await verifyD365CaseDetails(d365Page, expectedDetails)
 


### PR DESCRIPTION
noticed that D365 takes longer to create the case

## Description

- cater for D365 slowness


## Changes

- [ ] Feature/Scenario(s) added
- [ ] Steps definitions added/modified.
- [ ] Core framework changes

## Notes to Reviewers

- Share any specific context reviewers should know.
- If testing the PR requires setup, outline instructions clearly.
