### PR TITLE
Fix coordinate entry method heading to match updated app text

### DIFF
--- a/test/features/exemptions/validation.site.details.feature
+++ b/test/features/exemptions/validation.site.details.feature
@@ -14,7 +14,7 @@ Feature: Validation of Site details: the user is prevented from proceeding with 
     Given a user is providing site details
     And the "How do you want to enter the site coordinates?" page has been reached
     When the Continue button is clicked without selecting a coordinate entry method
-    Then the coordinates entry method error: "Select how you want to enter the coordinates" is displayed
+    Then the coordinates entry method error: "Select how you want to enter the site coordinates" is displayed
 
   Scenario: User is prevented from proceeding without selecting a coordinate system
     Given a user is providing site details

--- a/test/features/exemptions/validation.site.details.feature
+++ b/test/features/exemptions/validation.site.details.feature
@@ -12,7 +12,7 @@ Feature: Validation of Site details: the user is prevented from proceeding with 
 
   Scenario: User is prevented from proceeding without selecting a coordinate entry method
     Given a user is providing site details
-    And the "How do you want to enter the coordinates?" page has been reached
+    And the "How do you want to enter the site coordinates?" page has been reached
     When the Continue button is clicked without selecting a coordinate entry method
     Then the coordinates entry method error: "Select how you want to enter the coordinates" is displayed
 

--- a/test/steps/site.details.validation.steps.js
+++ b/test/steps/site.details.validation.steps.js
@@ -84,7 +84,7 @@ Given(
 )
 
 Given(
-  'the "How do you want to enter the coordinates?" page has been reached',
+  'the "How do you want to enter the site coordinates?" page has been reached',
   async function () {
     const site = this.data.siteDetails.sites[0]
     await selectProvideMethod(this.page, 'enter-manually')
@@ -92,7 +92,7 @@ Given(
     await enterActivityDates(this.page, site.activityDates)
     await enterActivityDescription(this.page, site.activityDescription)
     await expect(this.page.locator('h1')).toContainText(
-      'How do you want to enter the coordinates?'
+      'How do you want to enter the site coordinates?'
     )
   }
 )


### PR DESCRIPTION
The app heading changed from "How do you want to enter the coordinates?" to "How do you want to enter the site coordinates?"

Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/604


