### PR TITLE
ML-1229 add sceanrios for activity description,maximum duration,completion date

### DIFF
--- a/test/features/lcml/lcml.activity.description.feature
+++ b/test/features/lcml/lcml.activity.description.feature
@@ -1,0 +1,30 @@
+@lcml
+Feature: LCML: Activity description for an activity on a site
+  As an applicant
+  I want to provide an activity description for each activity at each site
+  So that the MMO knows what is being done at each site
+
+  Scenario: Display the activity description page
+    Given an organisation user has uploaded a valid "KML" file and is on the review site details page
+    When the user selects the "Activity description" task for "Site 1 - Activity 1"
+    Then the "Activity description" page is displayed
+    And the page caption shows the project name and "Site 1 - Activity 1"
+    And the activity description textbox is empty
+
+  Scenario: Validation error when activity description exceeds 1000 characters
+    Given the user is on the activity description page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user enters an activity description with 1001 characters and saves
+    Then the activity description error "Activity description must be 1000 characters or less" is displayed
+
+  Scenario: Save activity description returns to review site details with the entered text
+    Given the user is on the activity description page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user enters a random activity description and saves
+    Then the user is returned to the review site details page
+    And the "Activity description" row for "Site 1 - Activity 1" shows the entered activity description
+    And the action for the "Activity description" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Change a previously saved activity description
+    Given an organisation user has saved a random activity description for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects the "Change" link for the "Activity description" row for "Site 1 - Activity 1"
+    Then the "Activity description" page is displayed
+    And the activity description textbox contains the previously entered description

--- a/test/features/lcml/lcml.apply.for.marine.licence.feature
+++ b/test/features/lcml/lcml.apply.for.marine.licence.feature
@@ -4,19 +4,19 @@ Feature: LCML: Apply for a marine licence
   I want to apply for a marine licence
   So that I can carry out licensable marine activities
 
-  Scenario: Organisation user can submit a marine licence with KML upload, other authorities Yes and sharing consent Yes
+  Scenario: Organisation user can submit a marine licence with other authorities Yes and sharing consent Yes
     Given an organisation user has completed all tasks with special legal powers "Yes", other authorities "Yes" and sharing consent "Yes"
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
 
-  Scenario: Intermediary user can submit a marine licence with shapefile upload, other authorities No and sharing consent No
+  Scenario: Intermediary user can submit a marine licence with other authorities No and sharing consent No
     Given an intermediary user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "No"
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
 
-  Scenario: Individual user can submit a marine licence with KML upload, other authorities No and sharing consent No
+  Scenario: Individual user can submit a marine licence with other authorities No and sharing consent No
     Given an individual user has completed all tasks with other authorities "No" and sharing consent "No"
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference

--- a/test/features/lcml/lcml.completion.date.feature
+++ b/test/features/lcml/lcml.completion.date.feature
@@ -1,0 +1,49 @@
+@lcml
+Feature: LCML: Completion date for an activity on a site
+  As an applicant
+  I want to indicate whether any part of the activity must be completed by a certain date
+  So that the MMO understands timing constraints on the activity
+
+  Scenario: Display the completion date page
+    Given an organisation user has uploaded a valid "KML" file and is on the review site details page
+    When the user selects the "Completion date" task for "Site 1 - Activity 1"
+    Then the completion date page is displayed
+    And the completion date page caption shows the project name and "Site 1 - Activity 1"
+    And neither completion date radio is selected and the reason textbox is hidden
+
+  Scenario: Selecting Yes reveals the reason textbox
+    Given the user is on the completion date page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects the "Yes" completion date option
+    Then the completion date reason textbox is visible
+
+  Scenario: Selecting No after Yes hides the reason textbox
+    Given the user is on the completion date page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects the "Yes" completion date option
+    And the user selects the "No" completion date option
+    Then the completion date reason textbox is hidden
+
+  Scenario: Validation error when reason exceeds 1000 characters
+    Given the user is on the completion date page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects "Yes" and enters a reason with 1001 characters and saves
+    Then the completion date reason error "Reasons for the completion date must be 1000 characters or less" is displayed
+
+  Scenario: Save Yes with a reason returns to review showing only the reason text
+    Given the user is on the completion date page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects "Yes" and enters "We need it ready before winter" as the reason and saves
+    Then the user is returned to the review site details page
+    And the "Completion date" row for "Site 1 - Activity 1" shows "We need it ready before winter"
+    And the action for the "Completion date" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Save No returns to review showing the not-needed message
+    Given the user is on the completion date page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects "No" and saves the completion date
+    Then the user is returned to the review site details page
+    And the "Completion date" row for "Site 1 - Activity 1" shows "Not needed to be completed by a certain date"
+    And the action for the "Completion date" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Change a previously saved Yes completion date
+    Given an organisation user has saved "Yes" with reason "Original reason text" for the completion date for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects the "Change" link for the "Completion date" row for "Site 1 - Activity 1"
+    Then the completion date page is displayed
+    And the "Yes" completion date radio is selected
+    And the completion date reason textbox contains "Original reason text"

--- a/test/features/lcml/lcml.maximum.duration.feature
+++ b/test/features/lcml/lcml.maximum.duration.feature
@@ -1,0 +1,35 @@
+@lcml
+Feature: LCML: Maximum duration of the activity for an activity on a site
+  As an applicant
+  I want to provide a maximum duration for each activity at each site
+  So that the MMO knows how long each activity will last
+
+  Scenario: Display the maximum duration of the activity page
+    Given an organisation user has uploaded a valid "KML" file and is on the review site details page
+    When the user selects the "Maximum duration of activity" task for "Site 1 - Activity 1"
+    Then the maximum duration of the activity page is displayed
+    And the duration page caption shows the project name and "Site 1 - Activity 1"
+    And the years and months textboxes are empty
+
+  Scenario: Save valid years and months returns to review with formatted value
+    Given the user is on the duration page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user enters "3" years and "6" months and saves
+    Then the user is returned to the review site details page
+    And the "Maximum duration of activity" row for "Site 1 - Activity 1" shows "3 years, 6 months"
+    And the action for the "Maximum duration of activity" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Save with zero months only displays the years value
+    Given the user is on the duration page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user enters "5" years and "0" months and saves
+    Then the "Maximum duration of activity" row for "Site 1 - Activity 1" shows "5 years"
+
+  Scenario: Save with zero years only displays the months value
+    Given the user is on the duration page for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user enters "0" years and "9" months and saves
+    Then the "Maximum duration of activity" row for "Site 1 - Activity 1" shows "9 months"
+
+  Scenario: Change a previously saved maximum duration
+    Given an organisation user has saved "2" years and "8" months as the duration for "Site 1 - Activity 1" after uploading a "KML" file
+    When the user selects the "Change" link for the "Maximum duration of activity" row for "Site 1 - Activity 1"
+    Then the maximum duration of the activity page is displayed
+    And the years textbox contains "2" and the months textbox contains "8"

--- a/test/steps/lcml.activity.description.steps.js
+++ b/test/steps/lcml.activity.description.steps.js
@@ -1,0 +1,197 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  loginAndNavigateToUploadPage,
+  uploadFileAndWaitForReviewPage
+} from '../support/lcml-helpers.js'
+
+const ACTIVITY_DESCRIPTION_FIELD = '#activityDescription'
+const ACTIVITY_DESCRIPTION_ERROR = '#activityDescription-error'
+const SAVE_AND_CONTINUE_BUTTON =
+  'button[type="submit"]:has-text("Save and continue")'
+
+function activityCardLocator(page, cardTitle) {
+  return page.locator(
+    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
+  )
+}
+
+function activityDescriptionRow(page, cardTitle) {
+  return activityCardLocator(page, cardTitle).locator(
+    '.govuk-summary-list__row:has(dt:text-is("Activity description"))'
+  )
+}
+
+async function clickActivityDescriptionAddLink(page, cardTitle) {
+  await activityDescriptionRow(page, cardTitle).locator('a:text("Add")').click()
+  await page.waitForLoadState('load')
+}
+
+async function fillActivityDescriptionAndSave(page, text) {
+  await page.locator(ACTIVITY_DESCRIPTION_FIELD).fill(text)
+  await page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+  await page.waitForLoadState('load')
+}
+
+async function expectOnActivityDescriptionPage(page) {
+  await expect(page.locator('h1')).toContainText('Activity description', {
+    timeout: 30_000
+  })
+}
+
+async function expectOnReviewSiteDetailsPage(page) {
+  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
+}
+
+When(
+  'the user selects the {string} task for {string}',
+  async function (taskName, cardTitle) {
+    const row = activityCardLocator(this.page, cardTitle).locator(
+      `.govuk-summary-list__row:has(dt:text-is("${taskName}"))`
+    )
+    await row.locator('a:text("Add")').click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then('the {string} page is displayed', async function (pageTitle) {
+  await expect(this.page.locator('h1')).toContainText(pageTitle, {
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the page caption shows the project name and {string}',
+  async function (activityLabel) {
+    await expect(
+      this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+    await expect(this.page.locator('main')).toContainText(activityLabel, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then('the activity description textbox is empty', async function () {
+  await expect(this.page.locator(ACTIVITY_DESCRIPTION_FIELD)).toHaveValue('', {
+    timeout: 30_000
+  })
+})
+
+Given(
+  'the user is on the activity description page for {string} after uploading a {string} file',
+  async function (cardTitle, fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+    await clickActivityDescriptionAddLink(this.page, cardTitle)
+    await expectOnActivityDescriptionPage(this.page)
+  }
+)
+
+When(
+  'the user enters an activity description with {int} characters and saves',
+  async function (length) {
+    const text = faker.string.alpha({ length })
+    await fillActivityDescriptionAndSave(this.page, text)
+  }
+)
+
+When(
+  'the user enters a random activity description and saves',
+  async function () {
+    const text = faker.lorem.sentence(8)
+    this.data.activityDescription = text
+    await fillActivityDescriptionAndSave(this.page, text)
+  }
+)
+
+Then(
+  'the activity description error {string} is displayed',
+  async function (errorMessage) {
+    await expect(this.page.locator(ACTIVITY_DESCRIPTION_ERROR)).toContainText(
+      errorMessage,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then('the user is returned to the review site details page', async function () {
+  await expectOnReviewSiteDetailsPage(this.page)
+})
+
+Then(
+  'the {string} row for {string} shows {string}',
+  async function (rowName, cardTitle, expectedValue) {
+    const row = activityCardLocator(this.page, cardTitle).locator(
+      `.govuk-summary-list__row:has(dt:text-is("${rowName}"))`
+    )
+    await expect(row.locator('.govuk-summary-list__value')).toContainText(
+      expectedValue,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then(
+  'the action for the {string} row for {string} is {string}',
+  async function (rowName, cardTitle, expectedAction) {
+    const row = activityCardLocator(this.page, cardTitle).locator(
+      `.govuk-summary-list__row:has(dt:text-is("${rowName}"))`
+    )
+    await expect(row.locator('.govuk-summary-list__actions a')).toContainText(
+      expectedAction,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Given(
+  'an organisation user has saved a random activity description for {string} after uploading a {string} file',
+  async function (cardTitle, fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+    const text = faker.lorem.sentence(8)
+    this.data.activityDescription = text
+    await clickActivityDescriptionAddLink(this.page, cardTitle)
+    await expectOnActivityDescriptionPage(this.page)
+    await fillActivityDescriptionAndSave(this.page, text)
+    await expectOnReviewSiteDetailsPage(this.page)
+  }
+)
+
+When(
+  'the user selects the {string} link for the {string} row for {string}',
+  async function (linkText, rowName, cardTitle) {
+    const row = activityCardLocator(this.page, cardTitle).locator(
+      `.govuk-summary-list__row:has(dt:text-is("${rowName}"))`
+    )
+    await row.locator(`a:text-is("${linkText}")`).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then(
+  'the {string} row for {string} shows the entered activity description',
+  async function (rowName, cardTitle) {
+    const row = this.page
+      .locator(
+        `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
+      )
+      .locator(`.govuk-summary-list__row:has(dt:text-is("${rowName}"))`)
+    await expect(row.locator('.govuk-summary-list__value')).toContainText(
+      this.data.activityDescription,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then(
+  'the activity description textbox contains the previously entered description',
+  async function () {
+    await expect(this.page.locator(ACTIVITY_DESCRIPTION_FIELD)).toHaveValue(
+      this.data.activityDescription,
+      { timeout: 30_000 }
+    )
+  }
+)

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -7,14 +7,15 @@ import {
   completeOtherAuthorities,
   completeSharingConsent,
   completeSiteDetailsViaFileUpload,
-  completeProjectBackground
+  completeProjectBackground,
+  pickRandomFileType
 } from '../support/lcml-helpers.js'
 
 Given(
   'an organisation user has completed all tasks with special legal powers {string}, other authorities {string} and sharing consent {string}',
   async function (slpAnswer, oaAnswer, consentAnswer) {
     await loginAndStartApplication(this, 'organisation')
-    await completeSiteDetailsViaFileUpload(this, 'KML')
+    await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
@@ -26,7 +27,7 @@ Given(
   'an intermediary user has completed all tasks with special legal powers {string}, other authorities {string} and sharing consent {string}',
   async function (slpAnswer, oaAnswer, consentAnswer) {
     await loginAndStartApplication(this, 'intermediary')
-    await completeSiteDetailsViaFileUpload(this, 'Shapefile')
+    await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
@@ -38,7 +39,7 @@ Given(
   'an individual user has completed all tasks with other authorities {string} and sharing consent {string}',
   async function (oaAnswer, consentAnswer) {
     await loginAndStartApplication(this, 'individual')
-    await completeSiteDetailsViaFileUpload(this, 'KML')
+    await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeOtherAuthorities(this.page, oaAnswer)
     await completeSharingConsent(this.page, consentAnswer)

--- a/test/steps/lcml.completion.date.steps.js
+++ b/test/steps/lcml.completion.date.steps.js
@@ -1,0 +1,178 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  loginAndNavigateToUploadPage,
+  uploadFileAndWaitForReviewPage
+} from '../support/lcml-helpers.js'
+
+const YES_RADIO = '#date'
+const NO_RADIO = '#date-2'
+const REASON_TEXTAREA = '#reason'
+const REASON_ERROR = '#reason-error'
+const SAVE_AND_CONTINUE_BUTTON =
+  'button[type="submit"]:has-text("Save and continue")'
+
+function activityCardLocator(page, cardTitle) {
+  return page.locator(
+    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
+  )
+}
+
+function completionDateRow(page, cardTitle) {
+  return activityCardLocator(page, cardTitle).locator(
+    '.govuk-summary-list__row:has(dt:text-is("Completion date"))'
+  )
+}
+
+async function clickCompletionDateAddLink(page, cardTitle) {
+  await completionDateRow(page, cardTitle).locator('a:text-is("Add")').click()
+  await page.waitForLoadState('load')
+}
+
+async function expectOnCompletionDatePage(page) {
+  await expect(page.locator('h1')).toContainText(
+    'Does any part of the activity need to be completed by a certain date?',
+    { timeout: 30_000 }
+  )
+}
+
+async function expectOnReviewSiteDetailsPage(page) {
+  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
+}
+
+function radioByLabel(label) {
+  return label === 'Yes' ? YES_RADIO : NO_RADIO
+}
+
+Then('the completion date page is displayed', async function () {
+  await expectOnCompletionDatePage(this.page)
+})
+
+Then(
+  'the completion date page caption shows the project name and {string}',
+  async function (activityLabel) {
+    await expect(
+      this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+    await expect(this.page.locator('main')).toContainText(activityLabel, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'neither completion date radio is selected and the reason textbox is hidden',
+  async function () {
+    await expect(this.page.locator(YES_RADIO)).not.toBeChecked({
+      timeout: 30_000
+    })
+    await expect(this.page.locator(NO_RADIO)).not.toBeChecked({
+      timeout: 30_000
+    })
+    await expect(this.page.locator(REASON_TEXTAREA)).toBeHidden({
+      timeout: 30_000
+    })
+  }
+)
+
+Given(
+  'the user is on the completion date page for {string} after uploading a {string} file',
+  async function (cardTitle, fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+    await clickCompletionDateAddLink(this.page, cardTitle)
+    await expectOnCompletionDatePage(this.page)
+  }
+)
+
+When(
+  'the user selects the {string} completion date option',
+  async function (label) {
+    await this.page.locator(radioByLabel(label)).check()
+  }
+)
+
+Then('the completion date reason textbox is visible', async function () {
+  await expect(this.page.locator(REASON_TEXTAREA)).toBeVisible({
+    timeout: 30_000
+  })
+})
+
+Then('the completion date reason textbox is hidden', async function () {
+  await expect(this.page.locator(REASON_TEXTAREA)).toBeHidden({
+    timeout: 30_000
+  })
+})
+
+When(
+  'the user selects {string} and enters a reason with {int} characters and saves',
+  async function (label, length) {
+    await this.page.locator(radioByLabel(label)).check()
+    await this.page
+      .locator(REASON_TEXTAREA)
+      .fill(faker.string.alpha({ length }))
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user selects {string} and enters {string} as the reason and saves',
+  async function (label, reason) {
+    await this.page.locator(radioByLabel(label)).check()
+    await this.page.locator(REASON_TEXTAREA).fill(reason)
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user selects {string} and saves the completion date',
+  async function (label) {
+    await this.page.locator(radioByLabel(label)).check()
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then(
+  'the completion date reason error {string} is displayed',
+  async function (errorMessage) {
+    await expect(this.page.locator(REASON_ERROR)).toContainText(errorMessage, {
+      timeout: 30_000
+    })
+  }
+)
+
+Given(
+  'an organisation user has saved {string} with reason {string} for the completion date for {string} after uploading a {string} file',
+  async function (label, reason, cardTitle, fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+    await clickCompletionDateAddLink(this.page, cardTitle)
+    await expectOnCompletionDatePage(this.page)
+    await this.page.locator(radioByLabel(label)).check()
+    if (label === 'Yes') {
+      await this.page.locator(REASON_TEXTAREA).fill(reason)
+    }
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+    await expectOnReviewSiteDetailsPage(this.page)
+  }
+)
+
+Then('the {string} completion date radio is selected', async function (label) {
+  await expect(this.page.locator(radioByLabel(label))).toBeChecked({
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the completion date reason textbox contains {string}',
+  async function (expectedText) {
+    await expect(this.page.locator(REASON_TEXTAREA)).toHaveValue(expectedText, {
+      timeout: 30_000
+    })
+  }
+)

--- a/test/steps/lcml.maximum.duration.steps.js
+++ b/test/steps/lcml.maximum.duration.steps.js
@@ -1,0 +1,118 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import {
+  loginAndNavigateToUploadPage,
+  uploadFileAndWaitForReviewPage
+} from '../support/lcml-helpers.js'
+
+const YEARS_FIELD = '#activity-duration-years'
+const MONTHS_FIELD = '#activity-duration-months'
+const SAVE_AND_CONTINUE_BUTTON =
+  'button[type="submit"]:has-text("Save and continue")'
+
+function activityCardLocator(page, cardTitle) {
+  return page.locator(
+    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
+  )
+}
+
+function durationRow(page, cardTitle) {
+  return activityCardLocator(page, cardTitle).locator(
+    '.govuk-summary-list__row:has(dt:text-is("Maximum duration of activity"))'
+  )
+}
+
+async function clickDurationAddLink(page, cardTitle) {
+  await durationRow(page, cardTitle).locator('a:text-is("Add")').click()
+  await page.waitForLoadState('load')
+}
+
+async function fillDurationAndSave(page, years, months) {
+  await page.locator(YEARS_FIELD).fill(years)
+  await page.locator(MONTHS_FIELD).fill(months)
+  await page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+  await page.waitForLoadState('load')
+}
+
+async function expectOnDurationPage(page) {
+  await expect(page.locator('h1')).toContainText(
+    'What is the maximum duration of the activity?',
+    { timeout: 30_000 }
+  )
+}
+
+async function expectOnReviewSiteDetailsPage(page) {
+  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
+}
+
+Then(
+  'the maximum duration of the activity page is displayed',
+  async function () {
+    await expectOnDurationPage(this.page)
+  }
+)
+
+Then(
+  'the duration page caption shows the project name and {string}',
+  async function (activityLabel) {
+    const captions = this.page.locator(
+      '.govuk-caption-l, .govuk-caption-m, .govuk-caption-xl'
+    )
+    await expect(captions.first()).toContainText(this.data.projectName, {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('main')).toContainText(activityLabel, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then('the years and months textboxes are empty', async function () {
+  await expect(this.page.locator(YEARS_FIELD)).toHaveValue('', {
+    timeout: 30_000
+  })
+  await expect(this.page.locator(MONTHS_FIELD)).toHaveValue('', {
+    timeout: 30_000
+  })
+})
+
+Given(
+  'the user is on the duration page for {string} after uploading a {string} file',
+  async function (cardTitle, fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+    await clickDurationAddLink(this.page, cardTitle)
+    await expectOnDurationPage(this.page)
+  }
+)
+
+When(
+  'the user enters {string} years and {string} months and saves',
+  async function (years, months) {
+    await fillDurationAndSave(this.page, years, months)
+  }
+)
+
+Given(
+  'an organisation user has saved {string} years and {string} months as the duration for {string} after uploading a {string} file',
+  async function (years, months, cardTitle, fileType) {
+    await loginAndNavigateToUploadPage(this, fileType)
+    await uploadFileAndWaitForReviewPage(this, fileType)
+    await clickDurationAddLink(this.page, cardTitle)
+    await expectOnDurationPage(this.page)
+    await fillDurationAndSave(this.page, years, months)
+    await expectOnReviewSiteDetailsPage(this.page)
+  }
+)
+
+Then(
+  'the years textbox contains {string} and the months textbox contains {string}',
+  async function (yearsValue, monthsValue) {
+    await expect(this.page.locator(YEARS_FIELD)).toHaveValue(yearsValue, {
+      timeout: 30_000
+    })
+    await expect(this.page.locator(MONTHS_FIELD)).toHaveValue(monthsValue, {
+      timeout: 30_000
+    })
+  }
+)

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -16,6 +16,10 @@ const SAMPLE_FILES = {
   Shapefile: 'test/resources/valid-shapefile.zip'
 }
 
+export function pickRandomFileType() {
+  return faker.helpers.arrayElement(['KML', 'Shapefile'])
+}
+
 const USER_TYPE_CONFIG = {
   organisation: {
     userType: 'employee',
@@ -166,6 +170,80 @@ export async function uploadFileAndWaitForReviewPage(world, fileType) {
   await world.page.waitForLoadState('load')
 }
 
+function activityCardLocator(page, cardTitle) {
+  return page.locator(
+    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
+  )
+}
+
+async function clickAddLinkInActivityCard(page, cardTitle, rowName) {
+  await activityCardLocator(page, cardTitle)
+    .locator(`.govuk-summary-list__row:has(dt:text-is("${rowName}"))`)
+    .locator('a:text-is("Add")')
+    .click()
+  await page.waitForLoadState('load')
+}
+
+export async function completeActivityDescriptionForActivity(
+  page,
+  cardTitle,
+  description = faker.lorem.sentence(8)
+) {
+  await clickAddLinkInActivityCard(page, cardTitle, 'Activity description')
+  await page.locator('#activityDescription').fill(description)
+  await page
+    .locator('button[type="submit"]:has-text("Save and continue")')
+    .click()
+  await page.waitForLoadState('load')
+}
+
+export async function completeMaximumDurationForActivity(
+  page,
+  cardTitle,
+  years = '1',
+  months = '0'
+) {
+  await clickAddLinkInActivityCard(
+    page,
+    cardTitle,
+    'Maximum duration of activity'
+  )
+  await page.locator('#activity-duration-years').fill(years)
+  await page.locator('#activity-duration-months').fill(months)
+  await page
+    .locator('button[type="submit"]:has-text("Save and continue")')
+    .click()
+  await page.waitForLoadState('load')
+}
+
+export async function completeCompletionDateForActivity(
+  page,
+  cardTitle,
+  answer = 'No',
+  reason
+) {
+  await clickAddLinkInActivityCard(page, cardTitle, 'Completion date')
+  if (answer === 'Yes') {
+    await page.locator('#date').check()
+    await page.locator('#reason').fill(reason || faker.lorem.sentence(8))
+  } else {
+    await page.locator('#date-2').check()
+  }
+  await page
+    .locator('button[type="submit"]:has-text("Save and continue")')
+    .click()
+  await page.waitForLoadState('load')
+}
+
+export async function completeActivityDetailsFromReview(
+  page,
+  cardTitle = 'Site 1 - Activity 1'
+) {
+  await completeActivityDescriptionForActivity(page, cardTitle)
+  await completeMaximumDurationForActivity(page, cardTitle)
+  await completeCompletionDateForActivity(page, cardTitle, 'No')
+}
+
 export async function completeSiteDetailsViaFileUpload(
   world,
   fileType = 'KML'
@@ -180,6 +258,8 @@ export async function completeSiteDetailsViaFileUpload(
     './lcml-activity-flow.js'
   )
   await completeRandomActivityFromReviewPage(world)
+  // Fill the activity sub-tasks for Site 1 - Activity 1 from the Review page
+  await completeActivityDetailsFromReview(world.page, 'Site 1 - Activity 1')
   // Continue from review page → back to task list
   await world.page.locator('button:has-text("Continue")').click()
   await world.page.waitForLoadState('load')


### PR DESCRIPTION
Adding scenarios for the Activity description,
Adding scenario for  Maximum duration of the activity
Adding scenario Completion date pages reached from Review site details (display, max-character validation, save with formatted display, and change). 
Select KML/Shapefile randomly on each run.

ML-1229
ML-1231
ML-1230
