### PR TITLE
ML-1232 add LCML specific months and working hours tests

### DIFF
--- a/test/features/lcml/lcml.apply.for.marine.licence.feature
+++ b/test/features/lcml/lcml.apply.for.marine.licence.feature
@@ -6,18 +6,21 @@ Feature: LCML: Apply for a marine licence
 
   Scenario: Organisation user can submit a marine licence with other authorities Yes and sharing consent Yes
     Given an organisation user has completed all tasks with special legal powers "Yes", other authorities "Yes" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
 
   Scenario: Intermediary user can submit a marine licence with other authorities No and sharing consent No
     Given an intermediary user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "No"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
 
   Scenario: Individual user can submit a marine licence with other authorities No and sharing consent No
     Given an individual user has completed all tasks with other authorities "No" and sharing consent "No"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page

--- a/test/features/lcml/lcml.specific.months.feature
+++ b/test/features/lcml/lcml.specific.months.feature
@@ -1,0 +1,44 @@
+@lcml
+Feature: LCML: Activity limited to specific months for an activity on a site
+  As an applicant
+  I want to indicate whether the activity is limited to specific months of the year
+  So that the MMO understands the seasonal constraints on the activity
+
+  Scenario: Display the activity limited to specific months page
+    Given an organisation user has uploaded a coordinates file and is on the review site details page
+    When the user selects the "Activity limited to specific months" task for "Site 1 - Activity 1"
+    Then the activity limited to specific months page is displayed
+    And the specific months page caption shows the project name and "Site 1 - Activity 1"
+    And neither specific months radio is selected and the details textbox is hidden
+
+  Scenario: Selecting Yes reveals the details textbox
+    Given the user is on the specific months page for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user selects the "Yes" specific months option
+    Then the specific months details textbox is visible
+
+  Scenario: Selecting No after Yes hides the details textbox
+    Given the user is on the specific months page for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user selects the "Yes" specific months option
+    And the user selects the "No" specific months option
+    Then the specific months details textbox is hidden
+
+  Scenario: Save Yes with details returns to review showing only the details text
+    Given the user is on the specific months page for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user selects "Yes" and enters "Bad weather only allowed in summer" as specific months details and saves
+    Then the user is returned to the review site details page
+    And the "Activity limited to specific months" row for "Site 1 - Activity 1" shows "Bad weather only allowed in summer"
+    And the action for the "Activity limited to specific months" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Save No returns to review showing No
+    Given the user is on the specific months page for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user selects "No" and saves the specific months page
+    Then the user is returned to the review site details page
+    And the "Activity limited to specific months" row for "Site 1 - Activity 1" shows "No"
+    And the action for the "Activity limited to specific months" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Change a previously saved Yes specific months
+    Given an organisation user has saved "Yes" with specific months details "Original months text" for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user selects the "Change" link for the "Activity limited to specific months" row for "Site 1 - Activity 1"
+    Then the activity limited to specific months page is displayed
+    And the "Yes" specific months radio is selected
+    And the specific months details textbox contains "Original months text"

--- a/test/features/lcml/lcml.working.hours.feature
+++ b/test/features/lcml/lcml.working.hours.feature
@@ -1,0 +1,25 @@
+@lcml
+Feature: LCML: Proposed working hours for an activity on a site
+  As an applicant
+  I want to provide the proposed working hours for each activity at each site
+  So that the MMO knows when the activity will take place
+
+  Scenario: Display the proposed working hours page
+    Given an organisation user has uploaded a coordinates file and is on the review site details page
+    When the user selects the "Proposed working hours" task for "Site 1 - Activity 1"
+    Then the proposed working hours page is displayed
+    And the working hours page caption shows the project name and "Site 1 - Activity 1"
+    And the proposed working hours textbox is empty
+
+  Scenario: Save proposed working hours returns to review site details with the entered text
+    Given the user is on the proposed working hours page for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user enters random proposed working hours and saves
+    Then the user is returned to the review site details page
+    And the "Proposed working hours" row for "Site 1 - Activity 1" shows the entered proposed working hours
+    And the action for the "Proposed working hours" row for "Site 1 - Activity 1" is "Change"
+
+  Scenario: Change a previously saved proposed working hours
+    Given an organisation user has saved random proposed working hours for "Site 1 - Activity 1" after uploading a coordinates file
+    When the user selects the "Change" link for the "Proposed working hours" row for "Site 1 - Activity 1"
+    Then the proposed working hours page is displayed
+    And the proposed working hours textbox contains the previously entered value

--- a/test/steps/lcml.activity.description.steps.js
+++ b/test/steps/lcml.activity.description.steps.js
@@ -2,20 +2,15 @@ import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 import {
-  loginAndNavigateToUploadPage,
-  uploadFileAndWaitForReviewPage
+  activityCardLocator,
+  expectOnReviewSiteDetailsPage,
+  uploadCoordinatesFile
 } from '../support/lcml-helpers.js'
 
 const ACTIVITY_DESCRIPTION_FIELD = '#activityDescription'
 const ACTIVITY_DESCRIPTION_ERROR = '#activityDescription-error'
 const SAVE_AND_CONTINUE_BUTTON =
   'button[type="submit"]:has-text("Save and continue")'
-
-function activityCardLocator(page, cardTitle) {
-  return page.locator(
-    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
-  )
-}
 
 function activityDescriptionRow(page, cardTitle) {
   return activityCardLocator(page, cardTitle).locator(
@@ -38,10 +33,6 @@ async function expectOnActivityDescriptionPage(page) {
   await expect(page.locator('h1')).toContainText('Activity description', {
     timeout: 30_000
   })
-}
-
-async function expectOnReviewSiteDetailsPage(page) {
-  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
 }
 
 When(
@@ -82,8 +73,7 @@ Then('the activity description textbox is empty', async function () {
 Given(
   'the user is on the activity description page for {string} after uploading a {string} file',
   async function (cardTitle, fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
     await clickActivityDescriptionAddLink(this.page, cardTitle)
     await expectOnActivityDescriptionPage(this.page)
   }
@@ -149,8 +139,7 @@ Then(
 Given(
   'an organisation user has saved a random activity description for {string} after uploading a {string} file',
   async function (cardTitle, fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
     const text = faker.lorem.sentence(8)
     this.data.activityDescription = text
     await clickActivityDescriptionAddLink(this.page, cardTitle)

--- a/test/steps/lcml.activity.details.steps.js
+++ b/test/steps/lcml.activity.details.steps.js
@@ -1,8 +1,8 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import {
-  loginAndNavigateToUploadPage,
-  uploadFileAndWaitForReviewPage
+  uploadCoordinatesFile,
+  uploadRandomCoordinatesFile
 } from '../support/lcml-helpers.js'
 
 const ACTIVITY_FIELDS = [
@@ -17,8 +17,14 @@ const ACTIVITY_FIELDS = [
 Given(
   'an organisation user has uploaded a valid {string} file and is on the review site details page',
   async function (fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
+  }
+)
+
+Given(
+  'an organisation user has uploaded a coordinates file and is on the review site details page',
+  async function () {
+    await uploadRandomCoordinatesFile(this)
   }
 )
 

--- a/test/steps/lcml.activity.flow.steps.js
+++ b/test/steps/lcml.activity.flow.steps.js
@@ -24,9 +24,17 @@ import {
 
 function logSelection(world, prefix, topLevel, subOption) {
   const line = `${prefix} -> top-level "${topLevel}" / sub-option "${subOption.label}"`
-  console.log(`\n[lcml.activity.flow] ${line}`)
   if (world?.attach) {
     world.attach(line, 'text/plain')
+  }
+}
+
+function attachCheckbox(world, chosen) {
+  if (world?.attach) {
+    world.attach(
+      `checkbox -> id=${chosen.id} label="${chosen.label}"`,
+      'text/plain'
+    )
   }
 }
 
@@ -56,9 +64,7 @@ Given(
     await selectActivityTypeAndContinue(this.page, topLevel, subOption)
     const chosen = await pickRandomNonOtherCheckbox(this.page)
     this.data.activity.checkbox = chosen
-    console.log(
-      `[lcml.activity.flow] checkbox: id=${chosen.id} label="${chosen.label}"`
-    )
+    attachCheckbox(this, chosen)
     await checkCheckboxById(this.page, chosen.id)
     await checkCheckboxById(this.page, ACTIVITY_TYPES[topLevel].otherCheckboxId)
     await fillOtherTextarea(this.page, otherText)
@@ -83,9 +89,7 @@ When(
 When('the user selects a random checkbox and saves', async function () {
   const chosen = await pickRandomNonOtherCheckbox(this.page)
   this.data.activity.checkbox = chosen
-  console.log(
-    `[lcml.activity.flow] checkbox: id=${chosen.id} label="${chosen.label}"`
-  )
+  attachCheckbox(this, chosen)
   await checkCheckboxById(this.page, chosen.id)
   await submitWhatActivityForm(this.page)
 })

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -15,11 +15,11 @@ Given(
   'an organisation user has completed all tasks with special legal powers {string}, other authorities {string} and sharing consent {string}',
   async function (slpAnswer, oaAnswer, consentAnswer) {
     await loginAndStartApplication(this, 'organisation')
-    await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
     await completeSharingConsent(this.page, consentAnswer)
+    await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
   }
 )
 
@@ -46,15 +46,52 @@ Given(
   }
 )
 
+Then(
+  'the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved',
+  function () {
+    const cardTitle = 'Site 1 - Activity 1'
+    const activity = this.data.activity
+    expect(activity).toBeTruthy()
+    expect(typeof activity.topLevel).toBe('string')
+    expect(activity.subOption?.label).toBeTruthy()
+
+    const saved = this.data.activityDetails?.[cardTitle]
+    expect(saved).toBeTruthy()
+    expect(typeof saved.activityDescription).toBe('string')
+    expect(saved.activityDescription.length).toBeGreaterThan(0)
+    expect(saved.maxDuration?.years).toBeTruthy()
+    expect(saved.maxDuration?.months).toBeDefined()
+    expect(saved.completionDateAnswer).toMatch(/^(Yes|No)$/)
+    expect(saved.specificMonthsAnswer).toMatch(/^(Yes|No)$/)
+    expect(typeof saved.workingHours).toBe('string')
+    expect(saved.workingHours.length).toBeGreaterThan(0)
+  }
+)
+
 When(
   'the user submits the marine licence application from the task list',
   async function () {
+    // Task list → Check your answers
     await this.page.locator('#review-and-send').click()
     await this.page.waitForLoadState('load')
+    await expect(
+      this.page.locator('#check-your-answers-heading')
+    ).toContainText('Check your answers before sending your information', {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('main')).toContainText(
+      this.data.projectName,
+      { timeout: 30_000 }
+    )
 
+    // Check your answers → Declaration
     await this.page.locator('button:has-text("Continue")').click()
     await this.page.waitForLoadState('load')
+    await expect(this.page.locator('h1')).toContainText('Declaration', {
+      timeout: 30_000
+    })
 
+    // Declaration → Confirmation
     await this.page
       .locator('button:has-text("Confirm and send information")')
       .click()

--- a/test/steps/lcml.completion.date.steps.js
+++ b/test/steps/lcml.completion.date.steps.js
@@ -2,8 +2,9 @@ import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 import {
-  loginAndNavigateToUploadPage,
-  uploadFileAndWaitForReviewPage
+  activityCardLocator,
+  expectOnReviewSiteDetailsPage,
+  uploadCoordinatesFile
 } from '../support/lcml-helpers.js'
 
 const YES_RADIO = '#date'
@@ -12,12 +13,6 @@ const REASON_TEXTAREA = '#reason'
 const REASON_ERROR = '#reason-error'
 const SAVE_AND_CONTINUE_BUTTON =
   'button[type="submit"]:has-text("Save and continue")'
-
-function activityCardLocator(page, cardTitle) {
-  return page.locator(
-    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
-  )
-}
 
 function completionDateRow(page, cardTitle) {
   return activityCardLocator(page, cardTitle).locator(
@@ -35,10 +30,6 @@ async function expectOnCompletionDatePage(page) {
     'Does any part of the activity need to be completed by a certain date?',
     { timeout: 30_000 }
   )
-}
-
-async function expectOnReviewSiteDetailsPage(page) {
-  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
 }
 
 function radioByLabel(label) {
@@ -79,8 +70,7 @@ Then(
 Given(
   'the user is on the completion date page for {string} after uploading a {string} file',
   async function (cardTitle, fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
     await clickCompletionDateAddLink(this.page, cardTitle)
     await expectOnCompletionDatePage(this.page)
   }
@@ -148,8 +138,7 @@ Then(
 Given(
   'an organisation user has saved {string} with reason {string} for the completion date for {string} after uploading a {string} file',
   async function (label, reason, cardTitle, fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
     await clickCompletionDateAddLink(this.page, cardTitle)
     await expectOnCompletionDatePage(this.page)
     await this.page.locator(radioByLabel(label)).check()

--- a/test/steps/lcml.maximum.duration.steps.js
+++ b/test/steps/lcml.maximum.duration.steps.js
@@ -1,20 +1,15 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import {
-  loginAndNavigateToUploadPage,
-  uploadFileAndWaitForReviewPage
+  activityCardLocator,
+  expectOnReviewSiteDetailsPage,
+  uploadCoordinatesFile
 } from '../support/lcml-helpers.js'
 
 const YEARS_FIELD = '#activity-duration-years'
 const MONTHS_FIELD = '#activity-duration-months'
 const SAVE_AND_CONTINUE_BUTTON =
   'button[type="submit"]:has-text("Save and continue")'
-
-function activityCardLocator(page, cardTitle) {
-  return page.locator(
-    `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
-  )
-}
 
 function durationRow(page, cardTitle) {
   return activityCardLocator(page, cardTitle).locator(
@@ -39,10 +34,6 @@ async function expectOnDurationPage(page) {
     'What is the maximum duration of the activity?',
     { timeout: 30_000 }
   )
-}
-
-async function expectOnReviewSiteDetailsPage(page) {
-  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
 }
 
 Then(
@@ -79,8 +70,7 @@ Then('the years and months textboxes are empty', async function () {
 Given(
   'the user is on the duration page for {string} after uploading a {string} file',
   async function (cardTitle, fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
     await clickDurationAddLink(this.page, cardTitle)
     await expectOnDurationPage(this.page)
   }
@@ -96,8 +86,7 @@ When(
 Given(
   'an organisation user has saved {string} years and {string} months as the duration for {string} after uploading a {string} file',
   async function (years, months, cardTitle, fileType) {
-    await loginAndNavigateToUploadPage(this, fileType)
-    await uploadFileAndWaitForReviewPage(this, fileType)
+    await uploadCoordinatesFile(this, fileType)
     await clickDurationAddLink(this.page, cardTitle)
     await expectOnDurationPage(this.page)
     await fillDurationAndSave(this.page, years, months)

--- a/test/steps/lcml.specific.months.steps.js
+++ b/test/steps/lcml.specific.months.steps.js
@@ -1,0 +1,150 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import {
+  activityCardLocator,
+  expectOnReviewSiteDetailsPage,
+  uploadRandomCoordinatesFile
+} from '../support/lcml-helpers.js'
+
+const YES_RADIO = '#months'
+const NO_RADIO = '#months-2'
+const DETAILS_TEXTAREA = '#details'
+const SAVE_AND_CONTINUE_BUTTON =
+  'button[type="submit"]:has-text("Save and continue")'
+
+function specificMonthsRow(page, cardTitle) {
+  return activityCardLocator(page, cardTitle).locator(
+    '.govuk-summary-list__row:has(dt:text-is("Activity limited to specific months"))'
+  )
+}
+
+async function clickSpecificMonthsAddLink(page, cardTitle) {
+  await specificMonthsRow(page, cardTitle).locator('a:text-is("Add")').click()
+  await page.waitForLoadState('load')
+}
+
+async function expectOnSpecificMonthsPage(page) {
+  await expect(page.locator('h1')).toContainText(
+    'Will the activity be limited to specific months of the year?',
+    { timeout: 30_000 }
+  )
+}
+
+function radioByLabel(label) {
+  return label === 'Yes' ? YES_RADIO : NO_RADIO
+}
+
+Then(
+  'the activity limited to specific months page is displayed',
+  async function () {
+    await expectOnSpecificMonthsPage(this.page)
+  }
+)
+
+Then(
+  'the specific months page caption shows the project name and {string}',
+  async function (activityLabel) {
+    await expect(
+      this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+    await expect(this.page.locator('main')).toContainText(activityLabel, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'neither specific months radio is selected and the details textbox is hidden',
+  async function () {
+    await expect(this.page.locator(YES_RADIO)).not.toBeChecked({
+      timeout: 30_000
+    })
+    await expect(this.page.locator(NO_RADIO)).not.toBeChecked({
+      timeout: 30_000
+    })
+    await expect(this.page.locator(DETAILS_TEXTAREA)).toBeHidden({
+      timeout: 30_000
+    })
+  }
+)
+
+Given(
+  'the user is on the specific months page for {string} after uploading a coordinates file',
+  async function (cardTitle) {
+    await uploadRandomCoordinatesFile(this)
+    await clickSpecificMonthsAddLink(this.page, cardTitle)
+    await expectOnSpecificMonthsPage(this.page)
+  }
+)
+
+When(
+  'the user selects the {string} specific months option',
+  async function (label) {
+    await this.page.locator(radioByLabel(label)).check()
+  }
+)
+
+Then('the specific months details textbox is visible', async function () {
+  await expect(this.page.locator(DETAILS_TEXTAREA)).toBeVisible({
+    timeout: 30_000
+  })
+})
+
+Then('the specific months details textbox is hidden', async function () {
+  await expect(this.page.locator(DETAILS_TEXTAREA)).toBeHidden({
+    timeout: 30_000
+  })
+})
+
+When(
+  'the user selects {string} and enters {string} as specific months details and saves',
+  async function (label, details) {
+    await this.page.locator(radioByLabel(label)).check()
+    await this.page.locator(DETAILS_TEXTAREA).fill(details)
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user selects {string} and saves the specific months page',
+  async function (label) {
+    await this.page.locator(radioByLabel(label)).check()
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Given(
+  'an organisation user has saved {string} with specific months details {string} for {string} after uploading a coordinates file',
+  async function (label, details, cardTitle) {
+    await uploadRandomCoordinatesFile(this)
+    await clickSpecificMonthsAddLink(this.page, cardTitle)
+    await expectOnSpecificMonthsPage(this.page)
+    await this.page.locator(radioByLabel(label)).check()
+    if (label === 'Yes') {
+      await this.page.locator(DETAILS_TEXTAREA).fill(details)
+    }
+    await this.page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+    await this.page.waitForLoadState('load')
+    await expectOnReviewSiteDetailsPage(this.page)
+  }
+)
+
+Then('the {string} specific months radio is selected', async function (label) {
+  await expect(this.page.locator(radioByLabel(label))).toBeChecked({
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the specific months details textbox contains {string}',
+  async function (expectedText) {
+    await expect(this.page.locator(DETAILS_TEXTAREA)).toHaveValue(
+      expectedText,
+      {
+        timeout: 30_000
+      }
+    )
+  }
+)

--- a/test/steps/lcml.working.hours.steps.js
+++ b/test/steps/lcml.working.hours.steps.js
@@ -1,0 +1,112 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  activityCardLocator,
+  expectOnReviewSiteDetailsPage,
+  uploadRandomCoordinatesFile
+} from '../support/lcml-helpers.js'
+
+const WORKING_HOURS_FIELD = '#workingHours'
+const SAVE_AND_CONTINUE_BUTTON =
+  'button[type="submit"]:has-text("Save and continue")'
+
+function workingHoursRow(page, cardTitle) {
+  return activityCardLocator(page, cardTitle).locator(
+    '.govuk-summary-list__row:has(dt:text-is("Proposed working hours"))'
+  )
+}
+
+async function clickWorkingHoursAddLink(page, cardTitle) {
+  await workingHoursRow(page, cardTitle).locator('a:text-is("Add")').click()
+  await page.waitForLoadState('load')
+}
+
+async function fillWorkingHoursAndSave(page, text) {
+  await page.locator(WORKING_HOURS_FIELD).fill(text)
+  await page.locator(SAVE_AND_CONTINUE_BUTTON).click()
+  await page.waitForLoadState('load')
+}
+
+async function expectOnWorkingHoursPage(page) {
+  await expect(page.locator('h1')).toContainText(
+    'What are the proposed working hours?',
+    { timeout: 30_000 }
+  )
+}
+
+Then('the proposed working hours page is displayed', async function () {
+  await expectOnWorkingHoursPage(this.page)
+})
+
+Then(
+  'the working hours page caption shows the project name and {string}',
+  async function (activityLabel) {
+    await expect(
+      this.page.locator('.govuk-caption-l, .govuk-caption-m').first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+    await expect(this.page.locator('main')).toContainText(activityLabel, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then('the proposed working hours textbox is empty', async function () {
+  await expect(this.page.locator(WORKING_HOURS_FIELD)).toHaveValue('', {
+    timeout: 30_000
+  })
+})
+
+Given(
+  'the user is on the proposed working hours page for {string} after uploading a coordinates file',
+  async function (cardTitle) {
+    await uploadRandomCoordinatesFile(this)
+    await clickWorkingHoursAddLink(this.page, cardTitle)
+    await expectOnWorkingHoursPage(this.page)
+  }
+)
+
+When(
+  'the user enters random proposed working hours and saves',
+  async function () {
+    const text = faker.lorem.sentence(8)
+    this.data.workingHours = text
+    await fillWorkingHoursAndSave(this.page, text)
+  }
+)
+
+Then(
+  'the {string} row for {string} shows the entered proposed working hours',
+  async function (rowName, cardTitle) {
+    const row = activityCardLocator(this.page, cardTitle).locator(
+      `.govuk-summary-list__row:has(dt:text-is("${rowName}"))`
+    )
+    await expect(row.locator('.govuk-summary-list__value')).toContainText(
+      this.data.workingHours,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Given(
+  'an organisation user has saved random proposed working hours for {string} after uploading a coordinates file',
+  async function (cardTitle) {
+    await uploadRandomCoordinatesFile(this)
+    const text = faker.lorem.sentence(8)
+    this.data.workingHours = text
+    await clickWorkingHoursAddLink(this.page, cardTitle)
+    await expectOnWorkingHoursPage(this.page)
+    await fillWorkingHoursAndSave(this.page, text)
+    await expectOnReviewSiteDetailsPage(this.page)
+  }
+)
+
+Then(
+  'the proposed working hours textbox contains the previously entered value',
+  async function () {
+    await expect(this.page.locator(WORKING_HOURS_FIELD)).toHaveValue(
+      this.data.workingHours,
+      { timeout: 30_000 }
+    )
+  }
+)

--- a/test/support/lcml-activity-flow.js
+++ b/test/support/lcml-activity-flow.js
@@ -128,14 +128,12 @@ export async function completeRandomActivityFromReviewPage(world) {
   const { topLevel, subOption } = pickRandomActivity()
   world.data.activity = { topLevel, subOption }
   const line = `random activity -> "${topLevel}" / "${subOption.label}"`
-  console.log(`[lcml.activity] ${line}`)
   if (world.attach) {
     world.attach(line, 'text/plain')
   }
   await selectActivityTypeAndContinue(world.page, topLevel, subOption)
   const chosen = await pickRandomNonOtherCheckbox(world.page)
   world.data.activity.checkbox = chosen
-  console.log(`[lcml.activity] checkbox -> "${chosen.label}" (#${chosen.id})`)
   if (world.attach) {
     world.attach(`checkbox -> "${chosen.label}"`, 'text/plain')
   }

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -170,10 +170,27 @@ export async function uploadFileAndWaitForReviewPage(world, fileType) {
   await world.page.waitForLoadState('load')
 }
 
-function activityCardLocator(page, cardTitle) {
+export function activityCardLocator(page, cardTitle) {
   return page.locator(
     `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
   )
+}
+
+export async function expectOnReviewSiteDetailsPage(page) {
+  await expect(page).toHaveURL(/review-site-details/, { timeout: 30_000 })
+}
+
+export async function uploadCoordinatesFile(world, fileType) {
+  world.data.fileType = fileType
+  if (world.attach) {
+    world.attach(`file type -> ${fileType}`, 'text/plain')
+  }
+  await loginAndNavigateToUploadPage(world, fileType)
+  await uploadFileAndWaitForReviewPage(world, fileType)
+}
+
+export async function uploadRandomCoordinatesFile(world) {
+  await uploadCoordinatesFile(world, pickRandomFileType())
 }
 
 async function clickAddLinkInActivityCard(page, cardTitle, rowName) {
@@ -235,13 +252,102 @@ export async function completeCompletionDateForActivity(
   await page.waitForLoadState('load')
 }
 
+export async function completeSpecificMonthsForActivity(
+  page,
+  cardTitle,
+  answer = 'No',
+  details
+) {
+  await clickAddLinkInActivityCard(
+    page,
+    cardTitle,
+    'Activity limited to specific months'
+  )
+  if (answer === 'Yes') {
+    await page.locator('#months').check()
+    await page.locator('#details').fill(details || faker.lorem.sentence(8))
+  } else {
+    await page.locator('#months-2').check()
+  }
+  await page
+    .locator('button[type="submit"]:has-text("Save and continue")')
+    .click()
+  await page.waitForLoadState('load')
+}
+
+export async function completeWorkingHoursForActivity(
+  page,
+  cardTitle,
+  workingHours = faker.lorem.sentence(8)
+) {
+  await clickAddLinkInActivityCard(page, cardTitle, 'Proposed working hours')
+  await page.locator('#workingHours').fill(workingHours)
+  await page
+    .locator('button[type="submit"]:has-text("Save and continue")')
+    .click()
+  await page.waitForLoadState('load')
+}
+
 export async function completeActivityDetailsFromReview(
+  worldOrPage,
+  cardTitle = 'Site 1 - Activity 1'
+) {
+  const page = worldOrPage.page || worldOrPage
+  const world = worldOrPage.page ? worldOrPage : null
+
+  const description = faker.lorem.sentence(8)
+  const years = '1'
+  const months = '0'
+  const completionDateAnswer = 'No'
+  const specificMonthsAnswer = 'No'
+  const workingHoursText = faker.lorem.sentence(8)
+
+  await completeActivityDescriptionForActivity(page, cardTitle, description)
+  await completeMaximumDurationForActivity(page, cardTitle, years, months)
+  await completeCompletionDateForActivity(page, cardTitle, completionDateAnswer)
+  await completeSpecificMonthsForActivity(page, cardTitle, specificMonthsAnswer)
+  await completeWorkingHoursForActivity(page, cardTitle, workingHoursText)
+
+  if (world) {
+    world.data.activityDetails = world.data.activityDetails || {}
+    world.data.activityDetails[cardTitle] = {
+      activityDescription: description,
+      maxDuration: { years, months },
+      completionDateAnswer,
+      specificMonthsAnswer,
+      workingHours: workingHoursText
+    }
+  }
+}
+
+const ACTIVITY_CARD_ROWS = [
+  'Type of activity',
+  'Activity description',
+  'Maximum duration of activity',
+  'Completion date',
+  'Activity limited to specific months',
+  'Proposed working hours'
+]
+
+export async function verifyActivityCardCompleted(
   page,
   cardTitle = 'Site 1 - Activity 1'
 ) {
-  await completeActivityDescriptionForActivity(page, cardTitle)
-  await completeMaximumDurationForActivity(page, cardTitle)
-  await completeCompletionDateForActivity(page, cardTitle, 'No')
+  const card = activityCardLocator(page, cardTitle)
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  for (const rowName of ACTIVITY_CARD_ROWS) {
+    const row = card.locator(
+      `.govuk-summary-list__row:has(dt:text-is("${rowName}"))`
+    )
+    await expect(row.locator('.govuk-summary-list__value')).not.toContainText(
+      'Incomplete',
+      { timeout: 30_000 }
+    )
+    await expect(row.locator('.govuk-summary-list__actions a')).toContainText(
+      'Change',
+      { timeout: 30_000 }
+    )
+  }
 }
 
 export async function completeSiteDetailsViaFileUpload(
@@ -259,7 +365,9 @@ export async function completeSiteDetailsViaFileUpload(
   )
   await completeRandomActivityFromReviewPage(world)
   // Fill the activity sub-tasks for Site 1 - Activity 1 from the Review page
-  await completeActivityDetailsFromReview(world.page, 'Site 1 - Activity 1')
+  await completeActivityDetailsFromReview(world, 'Site 1 - Activity 1')
+  // Verify the card now shows all sub-tasks completed before leaving the page
+  await verifyActivityCardCompleted(world.page, 'Site 1 - Activity 1')
   // Continue from review page → back to task list
   await world.page.locator('button:has-text("Continue")').click()
   await world.page.waitForLoadState('load')


### PR DESCRIPTION
1) Add scenarios for the Activity limited to specific months and Proposed working hours pages reached from Review site details.
2) Extend the apply-for-marine-licence flow to fill all six activity sub-tasks for Site 1 - Activity 1,  
3) Randomise KML/Shapefile selection on each upload (with the choice attached to Allure) 

Closes:
ML-1233
ML-1232
ML-1230
ML-1231
