### PR TITLE
ML-1268 add IAT intermediate, terminal and multi-select page tests

### DIFF
--- a/test/features/iat/iat.intermediate.outcome.feature
+++ b/test/features/iat/iat.intermediate.outcome.feature
@@ -16,9 +16,9 @@ Feature: IAT: Intermediate outcome pages
       | Something else                                     |
     Then the IAT intermediate outcome page "/exemption/construction-exe-not-available-continue" is displayed
     And the IAT outcome options include:
-      | outcomeType                |
-      | WO_CON_NO_EXE_SELF_SERVICE |
-      | WO_NO_EXE_STANDARD_MLA     |
+      | option                                                                     |
+      | Check to see if the activity is suitable for self-service marine licensing |
+      | Apply for a standard marine licence                                        |
 
   Scenario: Deposit "exemption not available, continue" via the golden path
     Given the user starts the IAT
@@ -32,9 +32,9 @@ Feature: IAT: Intermediate outcome pages
       | Something else                                                |
     Then the IAT intermediate outcome page "/exemption/deposit-exe-not-available-continue" is displayed
     And the IAT outcome options include:
-      | outcomeType                    |
-      | WO_DEPOSIT_NO_EXE_SELF_SERVICE |
-      | WO_NO_EXE_STANDARD_MLA         |
+      | option                                                                     |
+      | Check to see if the activity is suitable for self-service marine licensing |
+      | Apply for a standard marine licence                                        |
 
   Scenario: Removal "exemption not available, continue" via the golden path
     Given the user starts the IAT
@@ -49,9 +49,9 @@ Feature: IAT: Intermediate outcome pages
       | Something else                                     |
     Then the IAT intermediate outcome page "/exemption/removal-exe-not-available-continue" is displayed
     And the IAT outcome options include:
-      | outcomeType                    |
-      | WO_REMOVAL_NO_EXE_SELF_SERVICE |
-      | WO_NO_EXE_STANDARD_MLA         |
+      | option                                                                     |
+      | Check to see if the activity is suitable for self-service marine licensing |
+      | Apply for a standard marine licence                                        |
 
   Scenario: Dredging "exemption not available, continue" via the golden path
     Given the user starts the IAT
@@ -63,9 +63,9 @@ Feature: IAT: Intermediate outcome pages
       | Something else                                     |
     Then the IAT intermediate outcome page "/exemption/dredging-exe-not-available-continue" is displayed
     And the IAT outcome options include:
-      | outcomeType                     |
-      | WO_DREDGING_NO_EXE_SELF_SERVICE |
-      | WO_NO_EXE_STANDARD_MLA          |
+      | option                                                                     |
+      | Check to see if the activity is suitable for self-service marine licensing |
+      | Apply for a standard marine licence                                        |
 
   Scenario Outline: <route> intermediate outcome page renders via direct URL
     Given the user navigates directly to the IAT outcome "<route>"

--- a/test/features/iat/iat.intermediate.outcome.feature
+++ b/test/features/iat/iat.intermediate.outcome.feature
@@ -1,0 +1,100 @@
+@iat @iatoutcome @iatintermediate
+Feature: IAT: Intermediate outcome pages
+  As an applicant using the IAT
+  I want intermediate outcome pages to present a choice of options
+  So that I can pick what to do next based on my activity
+
+  Scenario: Construction "exemption not available, continue" via the golden path
+    Given the user starts the IAT
+    When the user follows this IAT answer path:
+      | answer                                             |
+      | In or over the sea                                 |
+      | English waters or Northern Ireland offshore waters |
+      | Construction                                       |
+      | Build or make something new                        |
+      | Moorings or aids to navigation                     |
+      | Something else                                     |
+    Then the IAT intermediate outcome page "/exemption/construction-exe-not-available-continue" is displayed
+    And the IAT outcome options include:
+      | outcomeType                |
+      | WO_CON_NO_EXE_SELF_SERVICE |
+      | WO_NO_EXE_STANDARD_MLA     |
+
+  Scenario: Deposit "exemption not available, continue" via the golden path
+    Given the user starts the IAT
+    When the user follows this IAT answer path:
+      | answer                                                        |
+      | In or over the sea                                            |
+      | English waters or Northern Ireland offshore waters            |
+      | Deposit of a substance or object                              |
+      | From a vehicle or vessel                                      |
+      | Fishing or shellfish propagation and cultivation              |
+      | Something else                                                |
+    Then the IAT intermediate outcome page "/exemption/deposit-exe-not-available-continue" is displayed
+    And the IAT outcome options include:
+      | outcomeType                    |
+      | WO_DEPOSIT_NO_EXE_SELF_SERVICE |
+      | WO_NO_EXE_STANDARD_MLA         |
+
+  Scenario: Removal "exemption not available, continue" via the golden path
+    Given the user starts the IAT
+    When the user follows this IAT answer path:
+      | answer                                             |
+      | In or over the sea                                 |
+      | English waters or Northern Ireland offshore waters |
+      | Removal of a substance or object                   |
+      | Using a vehicle or vessel                          |
+      | Yes                                                |
+      | Fishing or shellfish propagation and cultivation   |
+      | Something else                                     |
+    Then the IAT intermediate outcome page "/exemption/removal-exe-not-available-continue" is displayed
+    And the IAT outcome options include:
+      | outcomeType                    |
+      | WO_REMOVAL_NO_EXE_SELF_SERVICE |
+      | WO_NO_EXE_STANDARD_MLA         |
+
+  Scenario: Dredging "exemption not available, continue" via the golden path
+    Given the user starts the IAT
+    When the user follows this IAT answer path:
+      | answer                                             |
+      | In or over the sea                                 |
+      | English waters or Northern Ireland offshore waters |
+      | Dredging                                           |
+      | Something else                                     |
+    Then the IAT intermediate outcome page "/exemption/dredging-exe-not-available-continue" is displayed
+    And the IAT outcome options include:
+      | outcomeType                     |
+      | WO_DREDGING_NO_EXE_SELF_SERVICE |
+      | WO_NO_EXE_STANDARD_MLA          |
+
+  Scenario Outline: <route> intermediate outcome page renders via direct URL
+    Given the user navigates directly to the IAT outcome "<route>"
+    When the user views the IAT outcome page
+    Then the IAT intermediate outcome page "<route>" is displayed
+
+    Examples:
+      | route                         |
+      | /construction/journey-select  |
+      | /deposit/journey-select       |
+      | /removal/journey-select       |
+      | /dredging/journey-select      |
+
+  Scenario Outline: Selecting "<option>" on <route> navigates to <expectedPath>
+    Given the user navigates directly to the IAT outcome "<route>"
+    When the user selects the "<option>" outcome option and clicks Continue
+    Then the IAT lands on path "<expectedPath>"
+
+    Examples:
+      | route                                              | option                                                                          | expectedPath                                          |
+      | /exemption/construction-exe-not-available-continue | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/construction/activity           |
+      | /exemption/deposit-exe-not-available-continue      | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/deposit/activity                |
+      | /exemption/removal-exe-not-available-continue      | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/removal/activity                |
+      | /exemption/dredging-exe-not-available-continue     | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/dredging/activity               |
+      | /construction/journey-select                       | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/construction          |
+      | /construction/journey-select                       | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/construction/activity           |
+      | /deposit/journey-select                            | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/deposit/activity-type |
+      | /deposit/journey-select                            | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/deposit/activity                |
+      | /removal/journey-select                            | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/removal/activity-type |
+      | /removal/journey-select                            | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/removal/activity                |
+      | /dredging/journey-select                           | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/dredging              |
+      | /dredging/journey-select                           | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/dredging/activity               |

--- a/test/features/iat/iat.multi.select.feature
+++ b/test/features/iat/iat.multi.select.feature
@@ -1,0 +1,24 @@
+@iat @iatmultiselect
+Feature: IAT: Multi-select (checkbox) question pages
+  As an applicant using the IAT
+  I want multi-select question pages to render checkboxes
+  So that I can pick one or more activities relevant to my project
+
+  Scenario: Display a multi-select question page
+    Given an anonymous user navigates directly to the IAT question "/dredging/activities"
+    When the user views the IAT question page
+    Then the IAT question page caption shows the section "Self-service check - Sub-activities" and heading contains "Please select sub-activites that match with activities proposed to be carried out."
+    And the IAT question page shows checkboxes named "answers" with a Back link and a Continue button
+    And the IAT question page has no header navigation links and any external guidance links open in a new tab
+
+  Scenario: Selecting checkboxes and continuing navigates to the next question
+    Given an anonymous user navigates directly to the IAT question "/dredging/activities"
+    When the user selects the IAT checkbox "Non-navigational clearance dredging (for operational purposes)"
+    And the user clicks the IAT Continue button
+    Then the IAT question page URL has changed from "/dredging/activities"
+
+  Scenario: Back link navigates away from the multi-select page with no answers pre-selected
+    Given an anonymous user navigates directly to the IAT question "/dredging/activities"
+    When the user clicks the IAT Back link
+    Then the IAT question page URL has changed from "/dredging/activities"
+    And no IAT checkbox is checked on the current question page

--- a/test/features/iat/iat.terminal.outcome.feature
+++ b/test/features/iat/iat.terminal.outcome.feature
@@ -1,17 +1,15 @@
 @iat @iatoutcome @iatterminal
 Feature: IAT: Terminal outcome pages
   As an applicant using the IAT
-  I want terminal outcome pages to give me a final result with placeholder actions
-  So that I can read the outcome, see a Continue button, and a "Download a PDF"
-  
+  I want terminal outcome pages to give me a final result
+  So that I can read the outcome and see a Continue button
 
-  Scenario Outline: Terminal outcome page "<route>" renders heading, body and placeholder actions
+  Scenario Outline: Terminal outcome page "<route>" renders heading, body and a Continue button
     Given an anonymous user navigates directly to the IAT outcome "<route>"
     When the user views the IAT outcome page
     Then the IAT terminal outcome page "<route>" is displayed with heading "<heading>"
     And the page has a body content block
-    And the page has a placeholder "Continue" button
-    And the page has a placeholder "Download a PDF record of my answers" button
+    And the page has a placeholder Continue button
 
     Examples:
       | route                                              | heading                                  |

--- a/test/features/iat/iat.terminal.outcome.feature
+++ b/test/features/iat/iat.terminal.outcome.feature
@@ -1,0 +1,20 @@
+@iat @iatoutcome @iatterminal
+Feature: IAT: Terminal outcome pages
+  As an applicant using the IAT
+  I want terminal outcome pages to give me a final result with placeholder actions
+  So that I can read the outcome, see a Continue button, and a "Download a PDF"
+  
+
+  Scenario Outline: Terminal outcome page "<route>" renders heading, body and placeholder actions
+    Given an anonymous user navigates directly to the IAT outcome "<route>"
+    When the user views the IAT outcome page
+    Then the IAT terminal outcome page "<route>" is displayed with heading "<heading>"
+    And the page has a body content block
+    And the page has a placeholder "Continue" button
+    And the page has a placeholder "Download a PDF record of my answers" button
+
+    Examples:
+      | route                                              | heading                                  |
+      | /fast-track-mla                                    | Self-service marine licensing            |
+      | /standard-marine-licence-application/construction  | Construction                             |
+      | /mod-permission                                    | MOD permission not sought or granted     |

--- a/test/steps/iat.intermediate.outcome.steps.js
+++ b/test/steps/iat.intermediate.outcome.steps.js
@@ -103,25 +103,18 @@ Then(
 )
 
 Then('the IAT outcome options include:', async function (dataTable) {
-  const expected = dataTable.hashes().map((row) => row.outcomeType)
-  for (const outcomeType of expected) {
-    const option = this.page.locator(
-      `.app-iat-option:has(input[name="outcomeType"][value="${outcomeType}"]), ` +
-        `.app-iat-option:has(h2:has-text("${outcomeType}"))`
-    )
-    // Non-terminal options carry the hidden input; terminal options don't, so
-    // accept the option being present on the page (matching by hidden input or
-    // by heading id) or fall back to the rendered options count.
-    const matched = await option.count()
-    if (matched === 0) {
-      // Terminal options have no form/hidden input. Verify the page shows at
-      // least one option whose heading matches the outcomeType heading we
-      // expect (set by JSON), by ensuring we have an Option section rendered.
-      const allOptions = await this.page.locator('.app-iat-option').count()
-      expect(allOptions).toBeGreaterThan(0)
-    } else {
-      await expect(option.first()).toBeVisible({ timeout: 30_000 })
-    }
+  // Match each expected option by its visible heading. The template renders
+  // each option block as `<h2>Option N - <heading></h2>`, so locating the
+  // .app-iat-option that contains an h2 with the heading text is unambiguous
+  // within a single page (headings vary across options within a page).
+  const expected = dataTable.hashes().map((row) => row.option)
+  for (const heading of expected) {
+    const option = this.page
+      .locator('.app-iat-option', {
+        has: this.page.locator('h2', { hasText: heading })
+      })
+      .first()
+    await expect(option).toBeVisible({ timeout: 30_000 })
   }
 })
 

--- a/test/steps/iat.intermediate.outcome.steps.js
+++ b/test/steps/iat.intermediate.outcome.steps.js
@@ -1,0 +1,136 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { getConfig } from '../support/config.js'
+import {
+  IAT_START_PATH,
+  OUTCOME_PREFIX,
+  navigateToOutcome
+} from '../support/iat-outcome.js'
+
+async function answerByLabel(world, label) {
+  // Match radio whose label text equals the supplied label, click it, take a
+  // screenshot showing the selection, attach to Allure, then submit.
+  const page = world.page
+  const questionHeading = (
+    await page
+      .locator('h1')
+      .first()
+      .innerText()
+      .catch(() => '')
+  ).trim()
+  const radio = page.locator(`label.govuk-radios__label:has-text("${label}")`)
+  await radio.first().click()
+  if (world.attach) {
+    try {
+      const png = await page.screenshot({ fullPage: true })
+      world.attach(png, 'image/png')
+      world.attach(`Q: "${questionHeading}" → A: "${label}"`, 'text/plain')
+    } catch {
+      // Ignore screenshot failures (page navigated, etc.)
+    }
+  }
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+}
+
+Given('the user starts the IAT', async function () {
+  const config = getConfig()
+  await this.page.goto(new URL(IAT_START_PATH, config.baseURL).toString())
+  await this.page.waitForLoadState('load')
+  await this.page
+    .locator(
+      'a.govuk-button:has-text("Start now"), button:has-text("Start now")'
+    )
+    .click()
+  await this.page.waitForLoadState('load')
+})
+
+Given(
+  'the user navigates directly to the IAT outcome {string}',
+  async function (route) {
+    await navigateToOutcome(this, route)
+  }
+)
+
+When('the user follows this IAT answer path:', async function (dataTable) {
+  const answers = dataTable.hashes().map((row) => row.answer)
+  for (const label of answers) {
+    await answerByLabel(this, label)
+  }
+})
+
+When('the user views the IAT outcome page', async function () {
+  await expect(this.page.locator('h1').first()).toBeVisible({ timeout: 30_000 })
+})
+
+When(
+  'the user selects the {string} outcome option and clicks Continue',
+  async function (heading) {
+    // Locate the option block whose h2 ends with the visible heading. The
+    // h2 renders as "Option N - <heading>", so match by the suffix.
+    const option = this.page
+      .locator('.app-iat-option', {
+        has: this.page.locator('h2', { hasText: heading })
+      })
+      .first()
+    const outcomeType = await option
+      .locator('input[name="outcomeType"]')
+      .getAttribute('value')
+    if (this.attach) {
+      this.attach(
+        `selected option -> "${heading}" (${outcomeType})`,
+        'text/plain'
+      )
+    }
+    await option.locator('form button:has-text("Continue")').click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then(
+  'the IAT intermediate outcome page {string} is displayed',
+  async function (route) {
+    await expect(this.page).toHaveURL(
+      new RegExp(
+        `${OUTCOME_PREFIX.replace(/\//g, '\\/')}${route.replace(/\//g, '\\/')}$`
+      ),
+      { timeout: 30_000 }
+    )
+    await expect(this.page.locator('h1').first()).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+Then('the IAT outcome options include:', async function (dataTable) {
+  const expected = dataTable.hashes().map((row) => row.outcomeType)
+  for (const outcomeType of expected) {
+    const option = this.page.locator(
+      `.app-iat-option:has(input[name="outcomeType"][value="${outcomeType}"]), ` +
+        `.app-iat-option:has(h2:has-text("${outcomeType}"))`
+    )
+    // Non-terminal options carry the hidden input; terminal options don't, so
+    // accept the option being present on the page (matching by hidden input or
+    // by heading id) or fall back to the rendered options count.
+    const matched = await option.count()
+    if (matched === 0) {
+      // Terminal options have no form/hidden input. Verify the page shows at
+      // least one option whose heading matches the outcomeType heading we
+      // expect (set by JSON), by ensuring we have an Option section rendered.
+      const allOptions = await this.page.locator('.app-iat-option').count()
+      expect(allOptions).toBeGreaterThan(0)
+    } else {
+      await expect(option.first()).toBeVisible({ timeout: 30_000 })
+    }
+  }
+})
+
+Then('the IAT lands on path {string}', async function (expectedPath) {
+  await expect(this.page).toHaveURL(
+    new RegExp(`${expectedPath.replace(/\//g, '\\/')}$`),
+    { timeout: 30_000 }
+  )
+  if (this.attach) {
+    this.attach(`redirected to -> ${expectedPath}`, 'text/plain')
+  }
+})

--- a/test/steps/iat.multi.select.steps.js
+++ b/test/steps/iat.multi.select.steps.js
@@ -1,0 +1,137 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { getConfig } from '../support/config.js'
+
+const QUESTION_PREFIX = '/journey/self-service'
+
+function questionUrl(baseURL, route) {
+  return new URL(`${QUESTION_PREFIX}${route}`, baseURL).toString()
+}
+
+Given(
+  'an anonymous user navigates directly to the IAT question {string}',
+  async function (route) {
+    const config = getConfig()
+    await this.page.goto(questionUrl(config.baseURL, route))
+    await this.page.waitForLoadState('load')
+    this.data.iatQuestionRoute = route
+    if (this.attach) {
+      this.attach(`question page -> ${route}`, 'text/plain')
+    }
+    // IAT routes are auth:false — assert we did not land on a sign-in page.
+    await expect(this.page).not.toHaveURL(/sign-in|login|defra-id-stub/, {
+      timeout: 5_000
+    })
+  }
+)
+
+When('the user views the IAT question page', async function () {
+  await expect(this.page.locator('h1').first()).toBeVisible({ timeout: 30_000 })
+})
+
+When('the user selects the IAT checkbox {string}', async function (label) {
+  const checkbox = this.page
+    .locator('.govuk-checkboxes__item', {
+      has: this.page.locator('label', { hasText: label })
+    })
+    .locator('input[type="checkbox"]')
+  await checkbox.first().check()
+  if (this.attach) {
+    this.attach(`checked checkbox -> "${label}"`, 'text/plain')
+  }
+})
+
+When('the user clicks the IAT Continue button', async function () {
+  await this.page.locator('button:has-text("Continue")').click()
+  await this.page.waitForLoadState('load')
+})
+
+When('the user clicks the IAT Back link', async function () {
+  await this.page.locator('a.govuk-back-link').click()
+  await this.page.waitForLoadState('load')
+})
+
+Then(
+  'the IAT question page caption shows the section {string} and heading contains {string}',
+  async function (sectionText, headingText) {
+    await expect(this.page.locator('.govuk-caption-l').first()).toContainText(
+      sectionText,
+      { timeout: 30_000 }
+    )
+    // The legend is rendered as <h1> via isPageHeading: true. The h1 contains
+    // both the caption span and the question text, so a substring match works.
+    await expect(this.page.locator('h1').first()).toContainText(headingText, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the IAT question page shows checkboxes named {string} with a Back link and a Continue button',
+  async function (fieldName) {
+    const checkboxes = this.page.locator(
+      `input[type="checkbox"][name="${fieldName}"]`
+    )
+    const count = await checkboxes.count()
+    expect(count).toBeGreaterThan(0)
+    await expect(this.page.locator('a.govuk-back-link')).toBeVisible({
+      timeout: 30_000
+    })
+    await expect(this.page.locator('button:has-text("Continue")')).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the IAT question page has no header navigation links and any external guidance links open in a new tab',
+  async function () {
+    // Service-navigation list links (Home / Projects / etc.) must not be
+    // rendered for the anonymous IAT.
+    const headerNavLinks = this.page.locator(
+      '.govuk-service-navigation__list a, .govuk-header__navigation a'
+    )
+    await expect(headerNavLinks).toHaveCount(0)
+    // Any anchor in main content pointing at an external URL must open in a
+    // new tab. (Currently the multi-select pages have no such links, so this
+    // is vacuously satisfied — but it'll start asserting the property the
+    // moment content authors add a guidance link to a multi-select page.)
+    const externals = await this.page
+      .locator('main a[href^="http"], main a[href^="https"]')
+      .evaluateAll((els) =>
+        els.map((a) => ({ href: a.getAttribute('href'), target: a.target }))
+      )
+    for (const link of externals) {
+      expect(link.target).toBe('_blank')
+    }
+  }
+)
+
+Then(
+  'the IAT question page URL has changed from {string}',
+  async function (originalRoute) {
+    // Anything but the original route is acceptable — proves navigation away.
+    await expect(this.page).not.toHaveURL(
+      new RegExp(
+        `${QUESTION_PREFIX.replace(/\//g, '\\/')}${originalRoute.replace(/\//g, '\\/')}$`
+      ),
+      { timeout: 30_000 }
+    )
+    if (this.attach) {
+      this.attach(
+        `navigated to -> ${new URL(this.page.url()).pathname}`,
+        'text/plain'
+      )
+    }
+  }
+)
+
+Then(
+  'no IAT checkbox is checked on the current question page',
+  async function () {
+    const checkedCount = await this.page
+      .locator('input[type="checkbox"]:checked')
+      .count()
+    expect(checkedCount).toBe(0)
+  }
+)

--- a/test/steps/iat.terminal.outcome.steps.js
+++ b/test/steps/iat.terminal.outcome.steps.js
@@ -1,0 +1,52 @@
+import { Given, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { OUTCOME_PREFIX, navigateToOutcome } from '../support/iat-outcome.js'
+
+Given(
+  'an anonymous user navigates directly to the IAT outcome {string}',
+  async function (route) {
+    // The IAT routes are configured with auth: false in the frontend, so a
+    // deep-link works without any login. Asserting we did not pass through a
+    // sign-in page proves the page is publicly accessible.
+    await navigateToOutcome(this, route)
+    await expect(this.page).not.toHaveURL(/sign-in|login|defra-id-stub/, {
+      timeout: 5_000
+    })
+  }
+)
+
+Then(
+  'the IAT terminal outcome page {string} is displayed with heading {string}',
+  async function (route, heading) {
+    await expect(this.page).toHaveURL(
+      new RegExp(
+        `${OUTCOME_PREFIX.replace(/\//g, '\\/')}${route.replace(/\//g, '\\/')}$`
+      ),
+      { timeout: 30_000 }
+    )
+    await expect(this.page.locator('h1').first()).toContainText(heading, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then('the page has a body content block', async function () {
+  // The terminal outcome template renders body text inside `.govuk-body`. For
+  // terminal-multi each option carries its own body block.
+  const bodies = this.page.locator('main .govuk-body')
+  await expect(bodies.first()).toBeVisible({ timeout: 30_000 })
+  const text = (await bodies.first().innerText()).trim()
+  expect(text.length).toBeGreaterThan(0)
+})
+
+Then('the page has a placeholder {string} button', async function (buttonText) {
+  // Continue / Download a PDF on terminal pages are placeholders today —
+  // anchor buttons with href="#" (see ML-1166 / ML-1167 / ML-1165).
+  const button = this.page.locator(
+    `main a.govuk-button:has-text("${buttonText}")`
+  )
+  await expect(button.first()).toBeVisible({ timeout: 30_000 })
+  await expect(button.first()).toHaveAttribute('href', '#', {
+    timeout: 30_000
+  })
+})

--- a/test/steps/iat.terminal.outcome.steps.js
+++ b/test/steps/iat.terminal.outcome.steps.js
@@ -39,14 +39,11 @@ Then('the page has a body content block', async function () {
   expect(text.length).toBeGreaterThan(0)
 })
 
-Then('the page has a placeholder {string} button', async function (buttonText) {
-  // Continue / Download a PDF on terminal pages are placeholders today —
-  // anchor buttons with href="#" (see ML-1166 / ML-1167 / ML-1165).
-  const button = this.page.locator(
-    `main a.govuk-button:has-text("${buttonText}")`
-  )
+Then('the page has a placeholder Continue button', async function () {
+  // The Continue button on terminal outcome pages is a placeholder pending
+  // ML-1166 (passing IAT context into exemption journey) and ML-1167 (passing
+  // context into MCMS journeys). It renders as an anchor with href="#".
+  const button = this.page.locator('main a.govuk-button:has-text("Continue")')
   await expect(button.first()).toBeVisible({ timeout: 30_000 })
-  await expect(button.first()).toHaveAttribute('href', '#', {
-    timeout: 30_000
-  })
+  await expect(button.first()).toHaveAttribute('href', '#', { timeout: 30_000 })
 })

--- a/test/support/iat-outcome.js
+++ b/test/support/iat-outcome.js
@@ -1,0 +1,17 @@
+import { getConfig } from './config.js'
+
+export const IAT_START_PATH = '/journey/self-service/start'
+export const OUTCOME_PREFIX = '/journey/self-service/outcome'
+
+export function outcomeUrl(baseURL, route) {
+  return new URL(`${OUTCOME_PREFIX}${route}`, baseURL).toString()
+}
+
+export async function navigateToOutcome(world, route) {
+  const config = getConfig()
+  await world.page.goto(outcomeUrl(config.baseURL, route))
+  await world.page.waitForLoadState('load')
+  if (world.attach) {
+    world.attach(`outcome page -> ${route}`, 'text/plain')
+  }
+}


### PR DESCRIPTION
Intermediate outcome: 4 scenarios exemption not available , Navigate directly to IAt outcome page  4( deposit,construction,removal,dredging), 12 scenarios via selfservice 

Terminal outcome pages: 3 scenarios (fast-track-mla, standard-marine-licence-application/construction , terminal-multi mod-permission) .

Multi-select question pages: 3 scenarios on /dredging/activities 

Covers
ML-1268
ML-1164
ML-1269