### PR TITLE
ML-1241 add LCML pre-application consultation task tests

### DIFF
--- a/test/features/lcml/lcml.pre.application.consultation.feature
+++ b/test/features/lcml/lcml.pre.application.consultation.feature
@@ -1,0 +1,43 @@
+@lcml @issue=ML-1241
+Feature: LCML: Pre-application consultation task
+  As an applicant
+  I want to record whether I have consulted with public groups or organisations
+  So that the MMO understands the context of my application
+
+  Scenario: Pre-application consultation task is displayed with "Not yet started"
+    Given an organisation user has started a marine licence application
+    When the user views the marine licence task list
+    Then the "Pre-application consultation" task is displayed with status "Not yet started"
+
+  Scenario: Page loads empty with toggleable guidance and toggleable details textbox
+    Given an organisation user has started a marine licence application
+    When the user opens the pre-application consultation task
+    Then the pre-application consultation page is empty with toggleable guidance
+    And selecting "Yes" reveals the details textbox
+    And selecting "No" hides the details textbox
+
+  Scenario Outline: Saving "<answer>" marks the pre-application consultation task Completed
+    Given an organisation user has started a marine licence application
+    When the user has saved "<answer>" with details "<details>" on pre-application consultation
+    Then the "Pre-application consultation" task status is "Completed"
+
+    Examples:
+      | answer | details                                                    |
+      | Yes    | Consulted the local conservation group and Natural England |
+      | No     |                                                            |
+
+  Scenario: Changing the consultation answer via Check your answers bounces back showing the new value
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    And the user has saved "Yes" with details "Initial consultation notes" on pre-application consultation
+    When the user opens the check your answers page from the task list
+    And the user changes the consultation answer to "No" via check your answers
+    Then the consultation answer on the check your answers page is "No"
+
+  Scenario: View details page shows the saved consultation answer as read-only
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    And the user has saved "Yes" with details "Met with the local fisheries forum" on pre-application consultation
+    When the user submits the marine licence application from the task list
+    And the user views the submitted application on the projects page
+    Then the consultation answer on the view details page is "Met with the local fisheries forum" and read-only

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -5,6 +5,7 @@ import {
   loginAndStartApplication,
   completeSpecialLegalPowers,
   completeOtherAuthorities,
+  completePublicConsultation,
   completeSharingConsent,
   completeSiteDetailsViaFileUpload,
   completeProjectBackground,
@@ -18,6 +19,7 @@ Given(
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
+    await completePublicConsultation(this.page)
     await completeSharingConsent(this.page, consentAnswer)
     await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
   }
@@ -31,6 +33,7 @@ Given(
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
+    await completePublicConsultation(this.page)
     await completeSharingConsent(this.page, consentAnswer)
   }
 )
@@ -42,6 +45,7 @@ Given(
     await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeOtherAuthorities(this.page, oaAnswer)
+    await completePublicConsultation(this.page)
     await completeSharingConsent(this.page, consentAnswer)
   }
 )

--- a/test/steps/lcml.pre.application.consultation.steps.js
+++ b/test/steps/lcml.pre.application.consultation.steps.js
@@ -1,0 +1,245 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { loginAndStartApplication } from '../support/lcml-helpers.js'
+
+const TASK_LINK = 'Pre-application consultation'
+const STATUS_ID = '#other-permissions-task-list-3-status'
+const PAGE_PATH = '/marine-licence/public-consultation'
+const TASK_LIST_PATH = '/marine-licence/task-list'
+const CONSULTATION_ROW_LABEL =
+  'Pre-application public groups or organisations consultation'
+
+function consultationRow(page) {
+  return page.locator(
+    `xpath=//div[contains(@class,"govuk-summary-list__row") and .//dt[normalize-space(text())="${CONSULTATION_ROW_LABEL}"]]`
+  )
+}
+
+function consultationPage(page) {
+  return {
+    yes: page.locator('#consulted'),
+    no: page.locator('#consulted-2'),
+    details: page.locator('#details'),
+    conditional: page.locator('#conditional-consulted'),
+    guidanceDetails: page.locator(
+      'details.govuk-details:has(summary:has-text("Help with pre-application and public consultation"))'
+    ),
+    saveButton: page.locator('button:has-text("Save and continue")')
+  }
+}
+
+async function openConsultationFromTaskList(page) {
+  await page.getByRole('link', { name: TASK_LINK }).click()
+  await page.waitForLoadState('load')
+}
+
+async function saveConsultation(page, answer, details) {
+  await openConsultationFromTaskList(page)
+  const c = consultationPage(page)
+  if (answer === 'Yes') {
+    await c.yes.click()
+    if (details) {
+      await c.details.fill(details)
+    }
+  } else {
+    await c.no.click()
+  }
+  await c.saveButton.click()
+  await page.waitForLoadState('load')
+}
+
+Given(
+  'an organisation user has started a marine licence application',
+  async function () {
+    await loginAndStartApplication(this, 'organisation')
+  }
+)
+
+Given(
+  'the user has saved {string} with details {string} on pre-application consultation',
+  async function (answer, details) {
+    await saveConsultation(this.page, answer, details)
+    await expect(this.page.locator(STATUS_ID)).toContainText('Completed', {
+      timeout: 30_000
+    })
+  }
+)
+
+When('the user views the marine licence task list', async function () {
+  await expect(this.page).toHaveURL(new RegExp(TASK_LIST_PATH))
+})
+
+When('the user opens the pre-application consultation task', async function () {
+  await openConsultationFromTaskList(this.page)
+})
+
+Then(
+  /^selecting "(Yes|No)" (reveals|hides) the details textbox$/,
+  async function (answer, action) {
+    const c = consultationPage(this.page)
+    if (answer === 'Yes') {
+      await c.yes.click()
+    } else {
+      await c.no.click()
+    }
+    const matcher = expect(c.conditional)
+    if (action === 'reveals') {
+      await matcher.not.toHaveClass(/govuk-radios__conditional--hidden/, {
+        timeout: 30_000
+      })
+      await expect(c.details).toBeVisible()
+    } else {
+      await matcher.toHaveClass(/govuk-radios__conditional--hidden/, {
+        timeout: 30_000
+      })
+    }
+  }
+)
+
+Then(
+  'the pre-application consultation page is empty with toggleable guidance',
+  async function () {
+    await expect(this.page).toHaveURL(new RegExp(PAGE_PATH), {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('h1')).toContainText(
+      'Have you consulted with any public groups or organisations before making this application?',
+      { timeout: 30_000 }
+    )
+    const c = consultationPage(this.page)
+    expect(await c.yes.isChecked()).toBe(false)
+    expect(await c.no.isChecked()).toBe(false)
+    await expect(c.conditional).toHaveClass(
+      /govuk-radios__conditional--hidden/,
+      { timeout: 30_000 }
+    )
+    const guidance = c.guidanceDetails
+    expect(await guidance.evaluate((el) => el.open)).toBe(false)
+    await guidance.locator('summary').click()
+    expect(await guidance.evaluate((el) => el.open)).toBe(true)
+    await guidance.locator('summary').click()
+    expect(await guidance.evaluate((el) => el.open)).toBe(false)
+  }
+)
+
+When(
+  'the user answers {string} with details {string} on the pre-application consultation page',
+  async function (answer, details) {
+    const c = consultationPage(this.page)
+    if (answer === 'Yes') {
+      await c.yes.click()
+      if (details) {
+        await c.details.fill(details)
+      }
+    } else {
+      await c.no.click()
+    }
+  }
+)
+
+When(
+  'the user clicks {string} on the pre-application consultation page',
+  async function (label) {
+    if (label !== 'Save and continue') {
+      throw new Error(`Unsupported action: ${label}`)
+    }
+    await consultationPage(this.page).saveButton.click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user opens the check your answers page from the task list',
+  async function () {
+    await this.page.locator('#review-and-send').click()
+    await this.page.waitForLoadState('load')
+    await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+When(
+  'the user changes the consultation answer to {string} via check your answers',
+  async function (answer) {
+    await consultationRow(this.page).locator('a:has-text("Change")').click()
+    await this.page.waitForLoadState('load')
+    const c = consultationPage(this.page)
+    if (answer === 'Yes') {
+      await c.yes.click()
+    } else {
+      await c.no.click()
+    }
+    await c.saveButton.click()
+    await this.page.waitForLoadState('load')
+    await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+When(
+  'the user views the submitted application on the projects page',
+  async function () {
+    await this.page.getByRole('link', { name: 'Projects' }).click()
+    await this.page.waitForLoadState('load')
+    const row = this.page.locator(
+      `xpath=//tr[td[contains(text(), "${this.data.projectName}")]]`
+    )
+    await row.locator('a:has-text("View details")').click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then('the pre-application consultation page is displayed', async function () {
+  await expect(this.page).toHaveURL(new RegExp(PAGE_PATH), { timeout: 30_000 })
+  await expect(this.page.locator('h1')).toContainText(
+    'Have you consulted with any public groups or organisations before making this application?',
+    { timeout: 30_000 }
+  )
+})
+
+Then('the {string} task is displayed', async function (taskName) {
+  await expect(this.page.getByRole('link', { name: taskName })).toBeVisible({
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the {string} task is displayed with status {string}',
+  async function (taskName, status) {
+    await expect(this.page.getByRole('link', { name: taskName })).toBeVisible({
+      timeout: 30_000
+    })
+    const statusLocator = this.page.locator(
+      `xpath=//a[normalize-space(text()) = "${taskName}"]/ancestor::li//div[contains(@class, "govuk-task-list__status")]`
+    )
+    await expect(statusLocator).toContainText(status, { timeout: 30_000 })
+  }
+)
+
+Then('the user is returned to the marine licence task list', async function () {
+  await expect(this.page).toHaveURL(new RegExp(TASK_LIST_PATH), {
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the consultation answer on the check your answers page is {string}',
+  async function (expected) {
+    await expect(
+      consultationRow(this.page).locator('dd').first()
+    ).toContainText(expected, { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the consultation answer on the view details page is {string} and read-only',
+  async function (expected) {
+    const row = consultationRow(this.page)
+    await expect(row.locator('dd').first()).toContainText(expected, {
+      timeout: 30_000
+    })
+    await expect(row.locator('a:has-text("Change")')).toHaveCount(0)
+  }
+)

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -115,6 +115,21 @@ export async function completeOtherAuthorities(page, answer) {
   await page.waitForLoadState('load')
 }
 
+export async function completePublicConsultation(page, answer = 'No') {
+  await page.locator('a:has-text("Pre-application consultation")').click()
+  await page.waitForLoadState('load')
+
+  if (answer === 'Yes') {
+    await page.locator('#consulted').click()
+    await page.locator('#details').fill(faker.lorem.sentence())
+  } else {
+    await page.locator('#consulted-2').click()
+  }
+
+  await page.locator('button:has-text("Save and continue")').click()
+  await page.waitForLoadState('load')
+}
+
 export async function completeSharingConsent(page, answer) {
   await page
     .locator('a:has-text("Sharing your project information publicly")')


### PR DESCRIPTION
Wiring the existing lcml test to include pre application consultation task
pre application consultation task scenarios


## Dependencies

Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/438
Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/694


