### PR TITLE
ML-1243 add preferred start and end dates of the licence task tests

### DIFF
--- a/test/features/lcml/lcml.preferred.dates.feature
+++ b/test/features/lcml/lcml.preferred.dates.feature
@@ -9,13 +9,6 @@ Feature: LCML: Preferred start and end dates of the licence task
     When the user views the marine licence task list
     Then the "Preferred start and end dates of the licence" task is displayed with status "Not yet started"
 
-  Scenario: Preferred dates page loads empty with dynamic hint text
-    Given an organisation user has started a marine licence application
-    When the user opens the preferred dates task
-    Then the preferred dates page is displayed with no pre-populated dates
-    And the start date hint shows the month 3 months from now
-    And the end date hint shows the month 15 months from now
-
   Scenario: Saving valid preferred dates marks the task Completed and returns to task list
     Given an organisation user has started a marine licence application
     When the user saves valid preferred dates on the preferred dates page

--- a/test/features/lcml/lcml.preferred.dates.feature
+++ b/test/features/lcml/lcml.preferred.dates.feature
@@ -1,0 +1,44 @@
+@lcml @issue=ML-1243
+Feature: LCML: Preferred start and end dates of the licence task
+  As an applicant
+  I want to provide details of preferred start and end dates of the licence
+  So that MMO know my preferred dates and can manage my application accordingly
+
+  Scenario: Preferred dates task is displayed with "Not yet started"
+    Given an organisation user has started a marine licence application
+    When the user views the marine licence task list
+    Then the "Preferred start and end dates of the licence" task is displayed with status "Not yet started"
+
+  Scenario: Preferred dates page loads empty with dynamic hint text
+    Given an organisation user has started a marine licence application
+    When the user opens the preferred dates task
+    Then the preferred dates page is displayed with no pre-populated dates
+    And the start date hint shows the month 3 months from now
+    And the end date hint shows the month 15 months from now
+
+  Scenario: Saving valid preferred dates marks the task Completed and returns to task list
+    Given an organisation user has started a marine licence application
+    When the user saves valid preferred dates on the preferred dates page
+    Then the "Preferred start and end dates of the licence" task is displayed with status "Completed"
+    And the user is on the marine licence task list
+
+  Scenario: Cancel returns to task list without changing the task status
+    Given an organisation user has started a marine licence application
+    When the user opens the preferred dates task
+    And the user cancels from the preferred dates page
+    Then the user is on the marine licence task list
+    And the "Preferred start and end dates of the licence" task is displayed with status "Not yet started"
+
+  Scenario: Changing preferred dates via Check your answers bounces back showing updated dates
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    When the user opens the check your answers page from the task list
+    And the user changes the preferred dates via check your answers
+    Then the check your answers page is displayed with the preferred dates section
+
+  Scenario: View details page shows the saved preferred dates as read-only
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    When the user submits the marine licence application from the task list
+    And the user views the submitted application on the projects page
+    Then the preferred dates are displayed as read-only on the view details page

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -6,6 +6,7 @@ import {
   completeSpecialLegalPowers,
   completeOtherAuthorities,
   completePublicConsultation,
+  completePreferredDates,
   completeSharingConsent,
   completeSiteDetailsViaFileUpload,
   completeProjectBackground,
@@ -20,6 +21,7 @@ Given(
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
     await completePublicConsultation(this.page)
+    await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
     await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
   }
@@ -34,6 +36,7 @@ Given(
     await completeSpecialLegalPowers(this.page, slpAnswer)
     await completeOtherAuthorities(this.page, oaAnswer)
     await completePublicConsultation(this.page)
+    await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
   }
 )
@@ -46,6 +49,7 @@ Given(
     await completeProjectBackground(this.page, faker.lorem.sentence(10))
     await completeOtherAuthorities(this.page, oaAnswer)
     await completePublicConsultation(this.page)
+    await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
   }
 )

--- a/test/steps/lcml.preferred.dates.steps.js
+++ b/test/steps/lcml.preferred.dates.steps.js
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 
 const TASK_LINK = 'Preferred start and end dates of the licence'
 const TASK_LIST_PATH = '/marine-licence/task-list'
-const PREFERRED_DATES_ROW_LABEL = 'Preferred dates'
+const PREFERRED_DATES_ROW_LABEL = 'Preferred start and end dates of the licence'
 
 const MONTHS = [
   'January',

--- a/test/steps/lcml.preferred.dates.steps.js
+++ b/test/steps/lcml.preferred.dates.steps.js
@@ -1,0 +1,189 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+const TASK_LINK = 'Preferred start and end dates of the licence'
+const PAGE_PATH = '/marine-licence/preferred-dates'
+const TASK_LIST_PATH = '/marine-licence/task-list'
+const PREFERRED_DATES_ROW_LABEL = 'Preferred dates'
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+]
+
+function computeOffsetDate(offsetMonths) {
+  const now = new Date()
+  const d = new Date(now.getFullYear(), now.getMonth() + offsetMonths, 1)
+  return { month: d.getMonth() + 1, year: d.getFullYear() }
+}
+
+function preferredDatesRow(page) {
+  return page.locator(
+    `xpath=//div[contains(@class,"govuk-summary-list__row") and .//dt[normalize-space(text())="${PREFERRED_DATES_ROW_LABEL}"]]`
+  )
+}
+
+function preferredDatesPage(page) {
+  return {
+    startMonth: page.locator('#start-date-month'),
+    startYear: page.locator('#start-date-year'),
+    endMonth: page.locator('#end-date-month'),
+    endYear: page.locator('#end-date-year'),
+    saveButton: page.locator('button:has-text("Save and continue")'),
+    cancelLink: page.locator('a:has-text("Cancel")')
+  }
+}
+
+async function openPreferredDatesFromTaskList(page) {
+  await page.getByRole('link', { name: TASK_LINK }).click()
+  await page.waitForLoadState('load')
+}
+
+async function fillAndSavePreferredDates(
+  page,
+  startMonth,
+  startYear,
+  endMonth,
+  endYear
+) {
+  const f = preferredDatesPage(page)
+  await f.startMonth.fill(String(startMonth))
+  await f.startYear.fill(String(startYear))
+  await f.endMonth.fill(String(endMonth))
+  await f.endYear.fill(String(endYear))
+  await f.saveButton.click()
+  await page.waitForLoadState('load')
+}
+
+When('the user opens the preferred dates task', async function () {
+  await openPreferredDatesFromTaskList(this.page)
+})
+
+When(
+  'the user saves valid preferred dates on the preferred dates page',
+  async function () {
+    await openPreferredDatesFromTaskList(this.page)
+    const start = computeOffsetDate(3)
+    const end = computeOffsetDate(15)
+    this.data.preferredDates = {
+      ...start,
+      endMonth: end.month,
+      endYear: end.year
+    }
+    await fillAndSavePreferredDates(
+      this.page,
+      start.month,
+      start.year,
+      end.month,
+      end.year
+    )
+  }
+)
+
+When('the user cancels from the preferred dates page', async function () {
+  const f = preferredDatesPage(this.page)
+  await f.cancelLink.click()
+  await this.page.waitForLoadState('load')
+})
+
+When(
+  'the user changes the preferred dates via check your answers',
+  async function () {
+    await preferredDatesRow(this.page).locator('a:has-text("Change")').click()
+    await this.page.waitForLoadState('load')
+    const newStart = computeOffsetDate(4)
+    const newEnd = computeOffsetDate(16)
+    await fillAndSavePreferredDates(
+      this.page,
+      newStart.month,
+      newStart.year,
+      newEnd.month,
+      newEnd.year
+    )
+    await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the preferred dates page is displayed with no pre-populated dates',
+  async function () {
+    await expect(this.page).toHaveURL(new RegExp(PAGE_PATH), {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('h1')).toContainText('Preferred', {
+      timeout: 30_000
+    })
+    const f = preferredDatesPage(this.page)
+    await expect(f.startMonth).toHaveValue('', { timeout: 30_000 })
+    await expect(f.startYear).toHaveValue('', { timeout: 30_000 })
+    await expect(f.endMonth).toHaveValue('', { timeout: 30_000 })
+    await expect(f.endYear).toHaveValue('', { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the start date hint shows the month {int} months from now',
+  async function (offsetMonths) {
+    const { month, year } = computeOffsetDate(offsetMonths)
+    const hint = this.page
+      .locator('[id*="start-date"][id*="hint"], .govuk-hint')
+      .first()
+    await expect(hint).toContainText(String(month), { timeout: 30_000 })
+    await expect(hint).toContainText(String(year), { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the end date hint shows the month {int} months from now',
+  async function (offsetMonths) {
+    const { month, year } = computeOffsetDate(offsetMonths)
+    const hints = this.page.locator('[id*="end-date"][id*="hint"], .govuk-hint')
+    const lastHint = hints.last()
+    await expect(lastHint).toContainText(String(month), { timeout: 30_000 })
+    await expect(lastHint).toContainText(String(year), { timeout: 30_000 })
+  }
+)
+
+Then('the user is on the marine licence task list', async function () {
+  await expect(this.page).toHaveURL(new RegExp(TASK_LIST_PATH), {
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the check your answers page is displayed with the preferred dates section',
+  async function () {
+    await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({
+      timeout: 30_000
+    })
+    const row = preferredDatesRow(this.page)
+    await expect(row).toBeVisible({ timeout: 30_000 })
+    const valueText = await row.locator('dd').first().textContent()
+    const monthNames = MONTHS.join('|')
+    expect(valueText).toMatch(new RegExp(monthNames))
+  }
+)
+
+Then(
+  'the preferred dates are displayed as read-only on the view details page',
+  async function () {
+    const row = preferredDatesRow(this.page)
+    await expect(row).toBeVisible({ timeout: 30_000 })
+    const valueText = await row.locator('dd').first().textContent()
+    const monthNames = MONTHS.join('|')
+    expect(valueText).toMatch(new RegExp(monthNames))
+    await expect(row.locator('a:has-text("Change")')).toHaveCount(0)
+  }
+)

--- a/test/steps/lcml.preferred.dates.steps.js
+++ b/test/steps/lcml.preferred.dates.steps.js
@@ -2,7 +2,6 @@ import { When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 
 const TASK_LINK = 'Preferred start and end dates of the licence'
-const PAGE_PATH = '/marine-licence/preferred-dates'
 const TASK_LIST_PATH = '/marine-licence/task-list'
 const PREFERRED_DATES_ROW_LABEL = 'Preferred dates'
 
@@ -113,46 +112,6 @@ When(
     await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({
       timeout: 30_000
     })
-  }
-)
-
-Then(
-  'the preferred dates page is displayed with no pre-populated dates',
-  async function () {
-    await expect(this.page).toHaveURL(new RegExp(PAGE_PATH), {
-      timeout: 30_000
-    })
-    await expect(this.page.locator('h1')).toContainText('Preferred', {
-      timeout: 30_000
-    })
-    const f = preferredDatesPage(this.page)
-    await expect(f.startMonth).toHaveValue('', { timeout: 30_000 })
-    await expect(f.startYear).toHaveValue('', { timeout: 30_000 })
-    await expect(f.endMonth).toHaveValue('', { timeout: 30_000 })
-    await expect(f.endYear).toHaveValue('', { timeout: 30_000 })
-  }
-)
-
-Then(
-  'the start date hint shows the month {int} months from now',
-  async function (offsetMonths) {
-    const { month, year } = computeOffsetDate(offsetMonths)
-    const hint = this.page
-      .locator('[id*="start-date"][id*="hint"], .govuk-hint')
-      .first()
-    await expect(hint).toContainText(String(month), { timeout: 30_000 })
-    await expect(hint).toContainText(String(year), { timeout: 30_000 })
-  }
-)
-
-Then(
-  'the end date hint shows the month {int} months from now',
-  async function (offsetMonths) {
-    const { month, year } = computeOffsetDate(offsetMonths)
-    const hints = this.page.locator('[id*="end-date"][id*="hint"], .govuk-hint')
-    const lastHint = hints.last()
-    await expect(lastHint).toContainText(String(month), { timeout: 30_000 })
-    await expect(lastHint).toContainText(String(year), { timeout: 30_000 })
   }
 )
 

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -130,6 +130,25 @@ export async function completePublicConsultation(page, answer = 'No') {
   await page.waitForLoadState('load')
 }
 
+export async function completePreferredDates(page) {
+  await page
+    .locator('a:has-text("Preferred start and end dates of the licence")')
+    .click()
+  await page.waitForLoadState('load')
+
+  const now = new Date()
+  const startDate = new Date(now.getFullYear(), now.getMonth() + 3, 1)
+  const endDate = new Date(now.getFullYear(), now.getMonth() + 15, 1)
+
+  await page.locator('#start-date-month').fill(String(startDate.getMonth() + 1))
+  await page.locator('#start-date-year').fill(String(startDate.getFullYear()))
+  await page.locator('#end-date-month').fill(String(endDate.getMonth() + 1))
+  await page.locator('#end-date-year').fill(String(endDate.getFullYear()))
+
+  await page.locator('button:has-text("Save and continue")').click()
+  await page.waitForLoadState('load')
+}
+
 export async function completeSharingConsent(page, answer) {
   await page
     .locator('a:has-text("Sharing your project information publicly")')


### PR DESCRIPTION
## Description

- test/features/lcml/lcml.preferred.dates.feature — New feature file with 6 scenarios covering: task displayed as "Not yet started", saving valid dates marks task "Completed", cancel returns without changing status, CYA bounce change, and view details read-only display.

- test/steps/lcml.preferred.dates.steps.js — Step definitions for all 6 scenarios. Dates are computed dynamically at runtime so the tests never go stale.

- test/support/lcml-helpers.js — Added completePreferredDates() helper that navigates to the task, fills in future start/end month+year values, and saves.

- test/steps/lcml.apply.steps.js — Added completePreferredDates to all three "completed all tasks" Given steps (organisation, intermediary, individual) to fix broken end-to-end submission tests now that preferred dates is a required task.


## Dependencies

Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/695
Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/439

