### PR TITLE
ML-1237 add LCML change site location tests

### DIFF
--- a/test/features/lcml/lcml.change.site.location.feature
+++ b/test/features/lcml/lcml.change.site.location.feature
@@ -1,0 +1,46 @@
+@lcml @issue=ML-1237
+Feature: LCML: Change site location
+  As an applicant
+  I want to replace the location of a site I provided by file upload
+  So that I can correct the site without losing its name or activity details
+
+  Scenario: A Change site location option is displayed for an uploaded site
+    Given an organisation user is on the upload file page for "KML"
+    When the user uploads a valid "KML" file and saves
+    Then a "Change site location" option is displayed for site 1
+
+  Scenario: Selecting Change site location opens the confirmation page
+    Given an organisation user has uploaded a valid "KML" file and is on the review site details page
+    When the user selects "Change site location" for site 1
+    Then the change site location confirmation page is displayed
+    And the confirmation page shows the site reference "Site 1"
+
+  Scenario: The confirmation page shows the site name when one has been provided
+    Given an organisation user has uploaded a valid "KML" file and added a site name
+    When the user selects "Change site location" for site 1
+    Then the change site location confirmation page is displayed
+    And the confirmation page shows the stored site name prefixed with "Site 1"
+
+  Scenario: Confirming the change opens the choose file type page
+    Given an organisation user is on the change site location confirmation page for site 1
+    When the user selects "Yes, change site location"
+    Then the choose file type page is displayed
+
+  Scenario: The change site location upload page asks for a single site file
+    Given an organisation user is on the change site location confirmation page for site 1
+    When the user confirms the change and chooses to upload a "KML" file
+    Then the upload file page asks for a single site file only
+    And the upload file page states point and line sites are not allowed
+
+  Scenario: Uploading a file containing more than one site is rejected
+    Given an organisation user is on the change site location upload page for site 1 with file type "KML"
+    When the user uploads a file containing more than one site
+    Then a single site upload error is displayed
+
+  Scenario: Replacing a site location retains the site name and activity details
+    Given an organisation user has uploaded a valid "KML" file, named site 1 and added activity details
+    When the user changes the location of site 1 by uploading a single "Shapefile" file
+    Then the review site details page is displayed scrolled to site 1
+    And the site 1 name is retained
+    And the site 1 activity details are retained
+    And the site 1 location reflects the new uploaded file

--- a/test/features/lcml/lcml.change.site.location.feature
+++ b/test/features/lcml/lcml.change.site.location.feature
@@ -4,11 +4,6 @@ Feature: LCML: Change site location
   I want to replace the location of a site I provided by file upload
   So that I can correct the site without losing its name or activity details
 
-  Scenario: A Change site location option is displayed for an uploaded site
-    Given an organisation user is on the upload file page for "KML"
-    When the user uploads a valid "KML" file and saves
-    Then a "Change site location" option is displayed for site 1
-
   Scenario: Selecting Change site location opens the confirmation page
     Given an organisation user has uploaded a valid "KML" file and is on the review site details page
     When the user selects "Change site location" for site 1
@@ -21,21 +16,12 @@ Feature: LCML: Change site location
     Then the change site location confirmation page is displayed
     And the confirmation page shows the stored site name prefixed with "Site 1"
 
-  Scenario: Confirming the change opens the choose file type page
-    Given an organisation user is on the change site location confirmation page for site 1
-    When the user selects "Yes, change site location"
-    Then the choose file type page is displayed
-
-  Scenario: The change site location upload page asks for a single site file
-    Given an organisation user is on the change site location confirmation page for site 1
-    When the user confirms the change and chooses to upload a "KML" file
-    Then the upload file page asks for a single site file only
-    And the upload file page states point and line sites are not allowed
-
-  Scenario: Uploading a file containing more than one site is rejected
+  Scenario: Uploading a file containing more than one site is rejected on the single-site upload page
     Given an organisation user is on the change site location upload page for site 1 with file type "KML"
     When the user uploads a file containing more than one site
-    Then a single site upload error is displayed
+    Then a single site upload error is displayed with message "Upload a file that contains a single site"
+    And the upload file page asks for a single site file only
+    And the upload file page states point and line sites are not allowed
 
   Scenario: Replacing a site location retains the site name and activity details
     Given an organisation user has uploaded a valid "KML" file, named site 1 and added activity details

--- a/test/steps/lcml.change.site.location.steps.js
+++ b/test/steps/lcml.change.site.location.steps.js
@@ -45,19 +45,6 @@ Given(
 )
 
 Given(
-  'an organisation user is on the change site location confirmation page for site {int}',
-  async function (siteNumber) {
-    await uploadCoordinatesFile(this, 'KML')
-    this.data.originalMapFilename = await getSiteMapFilename(
-      this.page,
-      siteNumber
-    )
-    await changeSiteLocationLink(this.page, siteNumber).click()
-    await this.page.waitForLoadState('load')
-  }
-)
-
-Given(
   'an organisation user is on the change site location upload page for site {int} with file type {string}',
   async function (siteNumber, fileType) {
     await uploadCoordinatesFile(this, 'KML')
@@ -87,25 +74,6 @@ When(
         `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("${linkText}")`
       )
       .click()
-    await this.page.waitForLoadState('load')
-  }
-)
-
-When('the user selects {string}', async function (buttonText) {
-  await this.page
-    .getByRole('button', { name: new RegExp(buttonText, 'i') })
-    .click()
-  await this.page.waitForLoadState('load')
-})
-
-When(
-  'the user confirms the change and chooses to upload a {string} file',
-  async function (fileType) {
-    await this.page
-      .getByRole('button', { name: /yes, change site location/i })
-      .click()
-    await this.page.waitForLoadState('load')
-    await selectFileType(this.page, fileType)
     await this.page.waitForLoadState('load')
   }
 )
@@ -153,17 +121,6 @@ When(
 )
 
 Then(
-  'a {string} option is displayed for site {int}',
-  async function (linkText, siteNumber) {
-    await expect(
-      this.page.locator(
-        `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("${linkText}")`
-      )
-    ).toBeVisible({ timeout: 30_000 })
-  }
-)
-
-Then(
   'the change site location confirmation page is displayed',
   async function () {
     await expect(this.page).toHaveURL(/change-site-location/, {
@@ -195,16 +152,6 @@ Then(
   }
 )
 
-Then('the choose file type page is displayed', async function () {
-  await expect(this.page).toHaveURL(/choose-file-type-to-upload/, {
-    timeout: 30_000
-  })
-  await expect(this.page.locator('h1').first()).toContainText(
-    'Which type of file do you want to upload?',
-    { timeout: 30_000 }
-  )
-})
-
 Then(
   'the upload file page asks for a single site file only',
   async function () {
@@ -226,16 +173,18 @@ Then(
   }
 )
 
-Then('a single site upload error is displayed', async function () {
-  await expect(this.page.locator('.govuk-error-summary')).toContainText(
-    'Upload a file that contains a single site',
-    { timeout: 30_000 }
-  )
-  await expect(this.page.locator('#file-id-error')).toContainText(
-    'Upload a file that contains a single site',
-    { timeout: 30_000 }
-  )
-})
+Then(
+  'a single site upload error is displayed with message {string}',
+  async function (message) {
+    await expect(this.page.locator('.govuk-error-summary')).toContainText(
+      message,
+      { timeout: 30_000 }
+    )
+    await expect(this.page.locator('#file-id-error')).toContainText(message, {
+      timeout: 30_000
+    })
+  }
+)
 
 Then(
   'the review site details page is displayed scrolled to site {int}',

--- a/test/steps/lcml.change.site.location.steps.js
+++ b/test/steps/lcml.change.site.location.steps.js
@@ -1,0 +1,287 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import {
+  uploadCoordinatesFile,
+  completeActivityDetailsFromReview
+} from '../support/lcml-helpers.js'
+import {
+  addSiteNameFromReview,
+  selectFileType,
+  uploadFile
+} from '../support/site-details-flow.js'
+import { completeRandomActivityFromReviewPage } from '../support/lcml-activity-flow.js'
+
+const SAMPLE_FILES = {
+  KML: 'test/resources/EXE_2025_00009-LOCATIONS.kml',
+  Shapefile: 'test/resources/valid-shapefile.zip',
+  // EXE_2025_00098-LOCATIONS.kml contains two(multiple sites)
+  'multi-site': 'test/resources/EXE_2025_00098-LOCATIONS.kml'
+}
+
+function changeSiteLocationLink(page, siteNumber) {
+  return page.locator(
+    `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("Change site location")`
+  )
+}
+
+// Reads the uploaded file name encoded in the map's data-site-details attribute
+async function getSiteMapFilename(page, siteNumber) {
+  const raw = await page
+    .locator(`#site-details-${siteNumber} .app-site-details-map`)
+    .getAttribute('data-site-details')
+  return JSON.parse(raw)?.uploadedFile?.filename
+}
+
+// --- Given ---
+
+Given(
+  'an organisation user has uploaded a valid {string} file, named site {int} and added activity details',
+  async function (fileType, siteNumber) {
+    await uploadCoordinatesFile(this, fileType)
+    this.data.siteName = await addSiteNameFromReview(this.page, siteNumber)
+    await completeRandomActivityFromReviewPage(this)
+    await completeActivityDetailsFromReview(this, 'Site 1 - Activity 1')
+  }
+)
+
+Given(
+  'an organisation user is on the change site location confirmation page for site {int}',
+  async function (siteNumber) {
+    await uploadCoordinatesFile(this, 'KML')
+    this.data.originalMapFilename = await getSiteMapFilename(
+      this.page,
+      siteNumber
+    )
+    await changeSiteLocationLink(this.page, siteNumber).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Given(
+  'an organisation user is on the change site location upload page for site {int} with file type {string}',
+  async function (siteNumber, fileType) {
+    await uploadCoordinatesFile(this, 'KML')
+    await changeSiteLocationLink(this.page, siteNumber).click()
+    await this.page.waitForLoadState('load')
+    await this.page
+      .getByRole('button', { name: /yes, change site location/i })
+      .click()
+    await this.page.waitForLoadState('load')
+    await selectFileType(this.page, fileType)
+    await this.page.waitForLoadState('load')
+  }
+)
+
+// --- When ---
+
+When(
+  'the user selects {string} for site {int}',
+  async function (linkText, siteNumber) {
+    // Remember the current location so cancel/back scenarios can assert no change
+    this.data.originalMapFilename = await getSiteMapFilename(
+      this.page,
+      siteNumber
+    )
+    await this.page
+      .locator(
+        `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("${linkText}")`
+      )
+      .click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When('the user selects {string}', async function (buttonText) {
+  await this.page
+    .getByRole('button', { name: new RegExp(buttonText, 'i') })
+    .click()
+  await this.page.waitForLoadState('load')
+})
+
+When(
+  'the user confirms the change and chooses to upload a {string} file',
+  async function (fileType) {
+    await this.page
+      .getByRole('button', { name: /yes, change site location/i })
+      .click()
+    await this.page.waitForLoadState('load')
+    await selectFileType(this.page, fileType)
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user uploads a file containing more than one site',
+  async function () {
+    await uploadFile(this.page, SAMPLE_FILES['multi-site'])
+    await this.page.waitForLoadState('load')
+    // Validation keeps us on the upload-file page; allow the spinner to settle
+    await this.page
+      .waitForURL((url) => !url.toString().includes('upload-and-wait'), {
+        timeout: 60_000
+      })
+      .catch(() => {})
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user changes the location of site {int} by uploading a single {string} file',
+  async function (siteNumber, fileType) {
+    this.data.originalMapFilename = await getSiteMapFilename(
+      this.page,
+      siteNumber
+    )
+    await changeSiteLocationLink(this.page, siteNumber).click()
+    await this.page.waitForLoadState('load')
+    await this.page
+      .getByRole('button', { name: /yes, change site location/i })
+      .click()
+    await this.page.waitForLoadState('load')
+    await selectFileType(this.page, fileType)
+    await this.page.waitForLoadState('load')
+    await uploadFile(this.page, SAMPLE_FILES[fileType])
+    await this.page.waitForLoadState('load')
+    await this.page
+      .waitForURL((url) => !url.toString().includes('upload-and-wait'), {
+        timeout: 60_000
+      })
+      .catch(() => {})
+    await this.page.waitForLoadState('load')
+    this.data.newFileName = SAMPLE_FILES[fileType].split('/').pop()
+  }
+)
+
+Then(
+  'a {string} option is displayed for site {int}',
+  async function (linkText, siteNumber) {
+    await expect(
+      this.page.locator(
+        `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("${linkText}")`
+      )
+    ).toBeVisible({ timeout: 30_000 })
+  }
+)
+
+Then(
+  'the change site location confirmation page is displayed',
+  async function () {
+    await expect(this.page).toHaveURL(/change-site-location/, {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('h1').first()).toContainText(
+      'Change site location',
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then(
+  'the confirmation page shows the site reference {string}',
+  async function (reference) {
+    await expect(this.page.locator('.govuk-inset-text')).toHaveText(reference, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the confirmation page shows the stored site name prefixed with {string}',
+  async function (prefix) {
+    await expect(this.page.locator('.govuk-inset-text')).toHaveText(
+      `${prefix}: ${this.data.siteName}`,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then('the choose file type page is displayed', async function () {
+  await expect(this.page).toHaveURL(/choose-file-type-to-upload/, {
+    timeout: 30_000
+  })
+  await expect(this.page.locator('h1').first()).toContainText(
+    'Which type of file do you want to upload?',
+    { timeout: 30_000 }
+  )
+})
+
+Then(
+  'the upload file page asks for a single site file only',
+  async function () {
+    await expect(this.page).toHaveURL(/upload-file/, { timeout: 30_000 })
+    await expect(
+      this.page.locator('main, #main-content').first()
+    ).toContainText('The file you upload must be for a single site', {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the upload file page states point and line sites are not allowed',
+  async function () {
+    await expect(
+      this.page.locator('main, #main-content').first()
+    ).toContainText('not a point or a line', { timeout: 30_000 })
+  }
+)
+
+Then('a single site upload error is displayed', async function () {
+  await expect(this.page.locator('.govuk-error-summary')).toContainText(
+    'Upload a file that contains a single site',
+    { timeout: 30_000 }
+  )
+  await expect(this.page.locator('#file-id-error')).toContainText(
+    'Upload a file that contains a single site',
+    { timeout: 30_000 }
+  )
+})
+
+Then(
+  'the review site details page is displayed scrolled to site {int}',
+  async function (siteNumber) {
+    await expect(this.page).toHaveURL(
+      new RegExp(`review-site-details#site-details-${siteNumber}`),
+      { timeout: 30_000 }
+    )
+    await expect(this.page.locator('h1').first()).toContainText(
+      'Review site details',
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then('the site {int} name is retained', async function (siteNumber) {
+  await expect(
+    this.page.locator(
+      `#site-details-${siteNumber} .govuk-summary-list__row:has(dt:text("Site name")) .govuk-summary-list__value`
+    )
+  ).toContainText(this.data.siteName, { timeout: 30_000 })
+})
+
+Then(
+  'the site {int} activity details are retained',
+  async function (siteNumber) {
+    const cardTitle = `Site ${siteNumber} - Activity 1`
+    const card = this.page.locator(
+      `.govuk-summary-card:has(.govuk-summary-card__title:text("${cardTitle}"))`
+    )
+    await expect(card).toBeVisible({ timeout: 30_000 })
+    await expect(
+      card.locator(
+        '.govuk-summary-list__row:has(dt:text("Activity description")) .govuk-summary-list__value'
+      )
+    ).toContainText(this.data.activityDetails[cardTitle].activityDescription, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the site {int} location reflects the new uploaded file',
+  async function (siteNumber) {
+    const filename = await getSiteMapFilename(this.page, siteNumber)
+    expect(filename).toBe(this.data.newFileName)
+    expect(filename).not.toBe(this.data.originalMapFilename)
+  }
+)


### PR DESCRIPTION
-Covers the Change site location option on the review site details page, 

- confirmation page (site reference and named-site formatting), 

- single-site file upload journey, single-site validation,

- retention of site name and activity details after replacement.



