### PR TITLE
ML-1239 add LCML review site details page journey tests (manual entry)

### DIFF
--- a/test/features/lcml/lcml.review.site.details.feature
+++ b/test/features/lcml/lcml.review.site.details.feature
@@ -1,0 +1,58 @@
+@lcml @issue=ML-1239
+Feature: LCML: Review site details page (manual entry)
+  As an applicant providing site details for a marine licence application
+  I want to review and change the details of the site(s) I have entered manually
+  So that I can confirm they are correct before sending my information
+
+  Scenario: A polygon site is displayed with its boundary coordinates and no dividing lines
+    Given an organisation user has manually entered a polygon site for a marine licence
+    When the user views the review site details page
+    Then the review site details page is displayed with the project name as the caption
+    And the polygon site card displays the entered boundary coordinates
+    And the coordinate rows have no dividing lines between them
+
+  Scenario: Continuing to the task list sets the Site details task to In progress
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user continues from the review site details page
+    Then the marine licence task list is displayed
+    And the "Site details" task status is "In progress"
+
+  Scenario: Saving a changed site name returns to the review page with the change saved
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user selects the "Site name" change link for the circular site
+    And the user changes the site name and saves
+    Then the review site details page is displayed at the site 1 anchor
+    And the site name on the review page shows the updated value
+
+  Scenario: Manually adding a second site shows it on the review page
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user selects the Add another site button
+    And the user manually enters another circular site
+    Then the review site details page is displayed at the site 2 anchor
+    And site 1 is displayed on the review page
+    And site 2 is displayed on the review page
+
+  Scenario: Deleting a site that is not the last re-numbers the remaining sites
+    Given an organisation user has manually entered two circular sites for a marine licence
+    When the user deletes site 1
+    Then the review site details page is displayed
+    And only 1 site is displayed on the review page
+    And the remaining site is re-numbered as site 1 with the second site name
+
+  Scenario: Deleting the last remaining site returns to the task list
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user deletes site 1
+    Then the marine licence task list is displayed
+    And the "Site details" task status is "Not yet started"
+
+  Scenario Outline: Selecting <option> on the delete confirmation page returns to review without deleting
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user selects the Delete site option for site 1
+    And the user selects "<option>" on the delete site confirmation page
+    Then the review site details page is displayed
+    And site 1 is displayed on the review page
+
+    Examples:
+      | option |
+      | Cancel |
+      | Back   |

--- a/test/features/lcml/lcml.review.site.details.feature
+++ b/test/features/lcml/lcml.review.site.details.feature
@@ -1,9 +1,10 @@
-@lcml @issue=ML-1239
+@lcml @issue=ML-1239  @issue=ML-1203  @issue=ML-1204 @issue=ML-1202  @issue=ML-1200
 Feature: LCML: Review site details page (manual entry)
   As an applicant providing site details for a marine licence application
   I want to review and change the details of the site(s) I have entered manually
   So that I can confirm they are correct before sending my information
 
+  @issue=ML-1239
   Scenario: A polygon site is displayed with its boundary coordinates and no dividing lines
     Given an organisation user has manually entered a polygon site for a marine licence
     When the user views the review site details page
@@ -11,19 +12,79 @@ Feature: LCML: Review site details page (manual entry)
     And the polygon site card displays the entered boundary coordinates
     And the coordinate rows have no dividing lines between them
 
+  @issue=ML-1239
   Scenario: Continuing to the task list sets the Site details task to In progress
     Given an organisation user has manually entered a circular site for a marine licence
     When the user continues from the review site details page
     Then the marine licence task list is displayed
     And the "Site details" task status is "In progress"
 
-  Scenario: Saving a changed site name returns to the review page with the change saved
+  @issue=ML-1203
+  Scenario Outline: The <field> change link opens a pre-populated page with no Cancel option
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user selects the "<field>" change link for the circular site
+    Then the "<page>" page is displayed
+    And the previous answer is pre-populated
+    And the page does not display a Cancel option
+
+    Examples:
+      | field                                  | page                                                  |
+      | Site name                              | Site name                                             |
+      | Single or multiple sets of coordinates | How do you want to enter the site coordinates?        |
+      | Coordinate system                      | Which coordinate system do you want to use?           |
+      | Coordinates at centre of site          | Enter the coordinates at the centre point of the site |
+      | Width of circular site                 | Enter the width of the circular site in metres        |
+
+  @issue=ML-1203
+  Scenario: Saving a changed answer returns to the review page at the site anchor with the change saved
     Given an organisation user has manually entered a circular site for a marine licence
     When the user selects the "Site name" change link for the circular site
     And the user changes the site name and saves
     Then the review site details page is displayed at the site 1 anchor
     And the site name on the review page shows the updated value
 
+  @issue=ML-1203
+  Scenario: Changing the coordinate system follows the knock-on flow back to the review page
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user selects the "Coordinate system" change link for the circular site
+    And the user changes the coordinate system and re-enters the centre point
+    And the user enters new centre point coordinates and continues
+    Then the review site details page is displayed at the site 1 anchor
+    And the coordinate system on the review page reflects the change
+    And the width of the circular site is retained on the review page
+
+  @issue=ML-1204
+  Scenario Outline: The <field> change link opens a pre-populated page with no Cancel option for a polygon site
+    Given an organisation user has manually entered a polygon site for a marine licence
+    When the user selects the "<field>" change link for the polygon site
+    Then the "<page>" page is displayed
+    And the previous answer is pre-populated
+    And the page does not display a Cancel option
+
+    Examples:
+      | field                                  | page                                                                |
+      | Site name                              | Site name                                                           |
+      | Single or multiple sets of coordinates | How do you want to enter the site coordinates?                      |
+      | Coordinate system                      | Which coordinate system do you want to use?                         |
+      | Start and end points                   | Enter multiple sets of coordinates to mark the boundary of the site |
+
+  @issue=ML-1204
+  Scenario: Saving a changed site name for a polygon site returns to the review page at the site anchor
+    Given an organisation user has manually entered a polygon site for a marine licence
+    When the user selects the "Site name" change link for the polygon site
+    And the user changes the site name and saves
+    Then the review site details page is displayed at the site 1 anchor
+    And the site name on the review page shows the updated value
+
+  @issue=ML-1204
+  Scenario: Changing the coordinate system for a polygon site follows the knock-on flow back to the review page
+    Given an organisation user has manually entered a polygon site for a marine licence
+    When the user selects the "Coordinate system" change link for the polygon site
+    And the user changes the coordinate system and re-enters the boundary coordinates
+    Then the review site details page is displayed at the site 1 anchor
+    And the coordinate system on the review page reflects the change
+
+  @issue=ML-1202
   Scenario: Manually adding a second site shows it on the review page
     Given an organisation user has manually entered a circular site for a marine licence
     When the user selects the Add another site button
@@ -32,6 +93,7 @@ Feature: LCML: Review site details page (manual entry)
     And site 1 is displayed on the review page
     And site 2 is displayed on the review page
 
+  @issue=ML-1200
   Scenario: Deleting a site that is not the last re-numbers the remaining sites
     Given an organisation user has manually entered two circular sites for a marine licence
     When the user deletes site 1
@@ -39,12 +101,14 @@ Feature: LCML: Review site details page (manual entry)
     And only 1 site is displayed on the review page
     And the remaining site is re-numbered as site 1 with the second site name
 
+  @issue=ML-1200
   Scenario: Deleting the last remaining site returns to the task list
     Given an organisation user has manually entered a circular site for a marine licence
     When the user deletes site 1
     Then the marine licence task list is displayed
     And the "Site details" task status is "Not yet started"
 
+  @issue=ML-1200
   Scenario Outline: Selecting <option> on the delete confirmation page returns to review without deleting
     Given an organisation user has manually entered a circular site for a marine licence
     When the user selects the Delete site option for site 1

--- a/test/pages/review.site.details.page.js
+++ b/test/pages/review.site.details.page.js
@@ -5,7 +5,6 @@ export default class ReviewSiteDetailsPage {
     this.page = page
   }
 
-  // Activity details card
   activityDatesChangeLink() {
     return this.page.locator(
       '#activity-details-card .govuk-summary-list__row:has(dt:text-is("Activity dates")) a:text("Change")'
@@ -58,6 +57,18 @@ export default class ReviewSiteDetailsPage {
   siteNameValue(siteNumber) {
     return this.page.locator(
       `#site-details-${siteNumber} .govuk-summary-list__row:has(dt:text("Site name")) .govuk-summary-list__value`
+    )
+  }
+
+  siteFieldChangeLink(siteNumber, fieldKey) {
+    return this.page.locator(
+      `#site-details-${siteNumber} .govuk-summary-list__row:has(dt.govuk-summary-list__key:text-is("${fieldKey}")) a:has-text("Change")`
+    )
+  }
+
+  siteFieldRowValue(siteNumber, fieldKey) {
+    return this.page.locator(
+      `#site-details-${siteNumber} .govuk-summary-list__row:has(dt.govuk-summary-list__key:text-is("${fieldKey}")) .govuk-summary-list__value`
     )
   }
 

--- a/test/steps/lcml.change.site.details.steps.js
+++ b/test/steps/lcml.change.site.details.steps.js
@@ -1,0 +1,42 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import ReviewSiteDetailsPage from '../pages/review.site.details.page.js'
+import {
+  submitPrimaryAndWait,
+  expectReviewSiteDetailsAnchor
+} from '../support/lcml-helpers.js'
+
+When(
+  'the user selects the {string} change link for the circular site',
+  async function (fieldKey) {
+    const review = new ReviewSiteDetailsPage(this.page)
+    await review.siteFieldChangeLink(1, fieldKey).click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When('the user changes the site name and saves', async function () {
+  const updated = `Updated Site ${faker.location.city()}`
+  this.data.updated = { ...(this.data.updated || {}), siteName: updated }
+  await this.page.locator('#siteName').fill(updated)
+  await submitPrimaryAndWait(this.page)
+})
+
+Then(
+  'the review site details page is displayed at the site {int} anchor',
+  async function (siteNumber) {
+    await expectReviewSiteDetailsAnchor(this.page, siteNumber)
+  }
+)
+
+Then(
+  'the site name on the review page shows the updated value',
+  async function () {
+    const review = new ReviewSiteDetailsPage(this.page)
+    await expect(review.siteNameValue(1)).toContainText(
+      this.data.updated.siteName,
+      { timeout: 30_000 }
+    )
+  }
+)

--- a/test/steps/lcml.change.site.details.steps.js
+++ b/test/steps/lcml.change.site.details.steps.js
@@ -3,18 +3,53 @@ import { expect } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 import ReviewSiteDetailsPage from '../pages/review.site.details.page.js'
 import {
+  enterCentrePointOSGB36,
+  selectCoordinateSystem,
+  enterPolygonCoordinatesOSGB36
+} from '../support/site-details-flow.js'
+import {
   submitPrimaryAndWait,
-  expectReviewSiteDetailsAnchor
+  expectReviewSiteDetailsAnchor,
+  expectFieldPrePopulated
 } from '../support/lcml-helpers.js'
+
+async function selectChangeLink(world, fieldKey) {
+  world.data.changeField = fieldKey
+  const review = new ReviewSiteDetailsPage(world.page)
+  await review.siteFieldChangeLink(1, fieldKey).click()
+  await world.page.waitForLoadState('load')
+}
 
 When(
   'the user selects the {string} change link for the circular site',
   async function (fieldKey) {
-    const review = new ReviewSiteDetailsPage(this.page)
-    await review.siteFieldChangeLink(1, fieldKey).click()
-    await this.page.waitForLoadState('load')
+    await selectChangeLink(this, fieldKey)
   }
 )
+
+When(
+  'the user selects the {string} change link for the polygon site',
+  async function (fieldKey) {
+    await selectChangeLink(this, fieldKey)
+  }
+)
+
+Then('the previous answer is pre-populated', async function () {
+  await expectFieldPrePopulated(
+    this.page,
+    this.data.changeField,
+    this.data.site
+  )
+})
+
+Then('the page does not display a Cancel option', async function () {
+  await expect(
+    this.page.getByRole('link', { name: 'Cancel', exact: true })
+  ).toHaveCount(0, { timeout: 30_000 })
+  await expect(
+    this.page.getByRole('button', { name: 'Cancel', exact: true })
+  ).toHaveCount(0, { timeout: 30_000 })
+})
 
 When('the user changes the site name and saves', async function () {
   const updated = `Updated Site ${faker.location.city()}`
@@ -22,6 +57,74 @@ When('the user changes the site name and saves', async function () {
   await this.page.locator('#siteName').fill(updated)
   await submitPrimaryAndWait(this.page)
 })
+
+// AC4 / AC5b — changing the coordinate system is a knock-on mini-flow: it routes
+// through the centre-point page (skipping width) back to the review page.
+When(
+  'the user changes the coordinate system and re-enters the centre point',
+  async function () {
+    // Circular site default is WGS84 -> switch to OSGB36.
+    await selectCoordinateSystem(this.page, 'OSGB36')
+    await this.page.waitForLoadState('load')
+    this.data.updated = {
+      ...(this.data.updated || {}),
+      coordinateSystem: 'OSGB36'
+    }
+  }
+)
+
+When(
+  'the user enters new centre point coordinates and continues',
+  async function () {
+    const eastings = '432675'
+    const northings = '181310'
+    this.data.updated = {
+      ...(this.data.updated || {}),
+      eastings,
+      northings
+    }
+    await enterCentrePointOSGB36(this.page, eastings, northings)
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user changes the coordinate system and re-enters the boundary coordinates',
+  async function () {
+    await selectCoordinateSystem(this.page, 'OSGB36')
+    await this.page.waitForLoadState('load')
+    this.data.updated = {
+      ...(this.data.updated || {}),
+      coordinateSystem: 'OSGB36'
+    }
+    await enterPolygonCoordinatesOSGB36(this.page, [
+      { eastings: '432675', northings: '181310' },
+      { eastings: '433000', northings: '181500' },
+      { eastings: '432800', northings: '181700' }
+    ])
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then(
+  'the coordinate system on the review page reflects the change',
+  async function () {
+    const review = new ReviewSiteDetailsPage(this.page)
+    await expect(
+      review.siteFieldRowValue(1, 'Coordinate system')
+    ).toContainText('OSGB36 (National Grid)', { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the width of the circular site is retained on the review page',
+  async function () {
+    const review = new ReviewSiteDetailsPage(this.page)
+    await expect(
+      review.siteFieldRowValue(1, 'Width of circular site')
+    ).toContainText(`${this.data.site.width} metres`, { timeout: 30_000 })
+  }
+)
 
 Then(
   'the review site details page is displayed at the site {int} anchor',

--- a/test/steps/lcml.review.site.details.steps.js
+++ b/test/steps/lcml.review.site.details.steps.js
@@ -1,0 +1,234 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  enterCircleSiteDetails,
+  completeTwoManualCircleSites,
+  expectReviewSiteDetailsPage as expectOnReviewPage,
+  siteCardRow,
+  siteCardRowValue,
+  coordinateSystemLines,
+  givenManualSite
+} from '../support/lcml-helpers.js'
+
+// --- Given ---
+
+Given(
+  'an organisation user has manually entered a circular site for a marine licence',
+  async function () {
+    await givenManualSite(this, 'circular')
+  }
+)
+
+Given(
+  'an organisation user has manually entered a polygon site for a marine licence',
+  async function () {
+    await givenManualSite(this, 'polygon')
+  }
+)
+
+// --- When ---
+
+When('the user views the review site details page', async function () {
+  await expectOnReviewPage(this.page)
+})
+
+When('the user continues from the review site details page', async function () {
+  await this.page.locator('button:has-text("Continue")').click()
+  await this.page.waitForLoadState('load')
+})
+
+// --- Then ---
+
+Then(
+  'the review site details page is displayed with the project name as the caption',
+  async function () {
+    await expectOnReviewPage(this.page)
+    await expect(
+      this.page
+        .locator('.govuk-caption-l, .govuk-caption-xl, .govuk-caption-m')
+        .first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the polygon site card displays the entered boundary coordinates',
+  async function () {
+    const page = this.page
+    const site = this.data.site
+
+    await expect(
+      page.locator('#site-details-1 .govuk-summary-card__title')
+    ).toHaveText('Site 1', { timeout: 30_000 })
+    await expect(siteCardRowValue(page, 'Site name')).toContainText(
+      site.siteName,
+      { timeout: 30_000 }
+    )
+    await expect(
+      siteCardRowValue(page, 'Single or multiple sets of coordinates')
+    ).toContainText(
+      'Enter multiple sets of coordinates to mark the boundary of the site',
+      { timeout: 30_000 }
+    )
+
+    const systemValue = siteCardRowValue(page, 'Coordinate system')
+    for (const line of coordinateSystemLines(site.coordinateSystem)) {
+      await expect(systemValue).toContainText(line, { timeout: 30_000 })
+    }
+
+    const formatPoint = (c) =>
+      site.coordinateSystem === 'OSGB36'
+        ? `${c.eastings}, ${c.northings}`
+        : `${c.latitude}, ${c.longitude}`
+
+    // First point is shown as "Start and end points".
+    await expect(siteCardRowValue(page, 'Start and end points')).toContainText(
+      formatPoint(site.coordinates[0]),
+      { timeout: 30_000 }
+    )
+
+    // Remaining points appear as "Point 2", "Point 3", ...
+    for (let i = 1; i < site.coordinates.length; i++) {
+      await expect(siteCardRowValue(page, `Point ${i + 1}`)).toContainText(
+        formatPoint(site.coordinates[i]),
+        { timeout: 30_000 }
+      )
+    }
+
+    await expect(siteCardRow(page, 'Map view')).toBeVisible({ timeout: 30_000 })
+  }
+)
+
+Then(
+  'the coordinate rows have no dividing lines between them',
+  async function () {
+    const page = this.page
+    // The "Start and end points" and intermediate "Point N" rows drop their
+    // bottom border via govuk-summary-list__row--no-border (AC9).
+    await expect(siteCardRow(page, 'Start and end points')).toHaveClass(
+      /govuk-summary-list__row--no-border/,
+      { timeout: 30_000 }
+    )
+    await expect(siteCardRow(page, 'Point 2')).toHaveClass(
+      /govuk-summary-list__row--no-border/,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then('the marine licence task list is displayed', async function () {
+  await expect(this.page.locator('h1').first()).toContainText(
+    'Marine licence start page',
+    { timeout: 30_000 }
+  )
+})
+
+// --- Add another site ---
+
+When('the user selects the Add another site button', async function () {
+  await this.page
+    .locator('button[name="add"]:has-text("Add another site")')
+    .click()
+  await this.page.waitForLoadState('load')
+})
+
+When('the user manually enters another circular site', async function () {
+  // Distinct coordinates from the first site — the app rejects a second site
+  // that duplicates an existing site's geometry.
+  this.data.addedSite = await enterCircleSiteDetails(this, {
+    siteName: `Added Site ${faker.location.city()}`,
+    latitude: '51.500000',
+    longitude: '-2.000000',
+    width: '30'
+  })
+})
+
+Then('site {int} is displayed on the review page', async function (siteNumber) {
+  const card = this.page.locator(`#site-details-${siteNumber}`)
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  await expect(card.locator('.govuk-summary-card__title')).toContainText(
+    `Site ${siteNumber}`,
+    { timeout: 30_000 }
+  )
+  // Site 1 is the originally entered site; site 2 is the one added via
+  // "Add another site". Verify the card shows that site's name.
+  const expectedName =
+    siteNumber === 1 ? this.data.site?.siteName : this.data.addedSite?.siteName
+  if (expectedName) {
+    await expect(
+      card.locator(
+        '.govuk-summary-list__row:has(dt.govuk-summary-list__key:text-is("Site name")) .govuk-summary-list__value'
+      )
+    ).toContainText(expectedName, { timeout: 30_000 })
+  }
+})
+
+// --- Deleting a site ---
+
+Given(
+  'an organisation user has manually entered two circular sites for a marine licence',
+  async function () {
+    await completeTwoManualCircleSites(this)
+    await expectOnReviewPage(this.page)
+  }
+)
+
+When(
+  'the user selects the Delete site option for site {int}',
+  async function (siteNumber) {
+    await this.page
+      .locator(
+        `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("Delete site")`
+      )
+      .click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user selects {string} on the delete site confirmation page',
+  async function (option) {
+    // Both the "Cancel" link and the "Back" link return to the review page
+    // without deleting the site.
+    const locator =
+      option === 'Back'
+        ? this.page.locator('.govuk-back-link')
+        : this.page.locator(`main a:has-text("${option}")`)
+    await locator.click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When('the user deletes site {int}', async function (siteNumber) {
+  await this.page
+    .locator(
+      `#site-details-${siteNumber} .govuk-summary-card__actions a:has-text("Delete site")`
+    )
+    .click()
+  await this.page.waitForLoadState('load')
+  await this.page.locator('button:has-text("Yes, delete site")').click()
+  await this.page.waitForLoadState('load')
+})
+
+// Note: `the review site details page is displayed` is defined in
+// lcml.activity.flow.steps.js and reused here.
+
+Then('only {int} site is displayed on the review page', async function (count) {
+  await expect(
+    this.page.locator('.govuk-summary-card[id^="site-details-"]')
+  ).toHaveCount(count, { timeout: 30_000 })
+})
+
+Then(
+  'the remaining site is re-numbered as site 1 with the second site name',
+  async function () {
+    await expect(
+      this.page.locator('#site-details-1 .govuk-summary-card__title')
+    ).toHaveText('Site 1', { timeout: 30_000 })
+    await expect(siteCardRowValue(this.page, 'Site name')).toContainText(
+      this.data.sites[1].siteName,
+      { timeout: 30_000 }
+    )
+  }
+)

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -7,7 +7,15 @@ import {
   selectProvideMethod,
   selectFileType,
   uploadFile,
-  addSiteNameFromReview
+  addSiteNameFromReview,
+  enterSiteName,
+  selectCoordinatesEntryMethod,
+  selectCoordinateSystem,
+  enterCentrePointWGS84,
+  enterCentrePointOSGB36,
+  enterWidth,
+  enterPolygonCoordinatesWGS84,
+  enterPolygonCoordinatesOSGB36
 } from './site-details-flow.js'
 import PublicRegisterPage from '../pages/public.register.page.js'
 
@@ -382,6 +390,166 @@ export async function verifyActivityCardCompleted(
       { timeout: 30_000 }
     )
   }
+}
+
+export async function navigateToManualSiteEntry(world) {
+  await world.page.locator('a:has-text("Site details")').click()
+  await world.page.waitForLoadState('load')
+  await continueFromBeforeYouStart(world.page)
+  await world.page.waitForLoadState('load')
+  await selectProvideMethod(world.page, 'enter-manually')
+  await world.page.waitForLoadState('load')
+}
+
+export async function enterCircleSiteDetails(world, options = {}) {
+  const {
+    siteName = `Barryshingles Bay ${faker.location.city()}`,
+    coordinateSystem = 'WGS84',
+    latitude = '50.000000',
+    longitude = '-1.000000',
+    eastings = '432675',
+    northings = '181310',
+    width = '20'
+  } = options
+
+  const page = world.page
+  await enterSiteName(page, siteName)
+  await page.waitForLoadState('load')
+  await selectCoordinatesEntryMethod(page, 'circle')
+  await page.waitForLoadState('load')
+  await selectCoordinateSystem(page, coordinateSystem)
+  await page.waitForLoadState('load')
+
+  if (coordinateSystem === 'WGS84') {
+    await enterCentrePointWGS84(page, latitude, longitude)
+  } else {
+    await enterCentrePointOSGB36(page, eastings, northings)
+  }
+  await page.waitForLoadState('load')
+  await enterWidth(page, width)
+  await page.waitForLoadState('load')
+
+  return {
+    siteType: 'circle',
+    siteName,
+    coordinateSystem,
+    latitude,
+    longitude,
+    eastings,
+    northings,
+    width
+  }
+}
+
+export async function completeManualCircleSite(world, options = {}) {
+  await loginAndReachTaskList(world)
+  await navigateToManualSiteEntry(world)
+  world.data.site = await enterCircleSiteDetails(world, options)
+  return world.data.site
+}
+
+export async function completeTwoManualCircleSites(world) {
+  const first = await completeManualCircleSite(world, {
+    siteName: `First Site ${faker.location.city()}`
+  })
+
+  await world.page
+    .locator('button[name="add"]:has-text("Add another site")')
+    .click()
+  await world.page.waitForLoadState('load')
+
+  const second = await enterCircleSiteDetails(world, {
+    siteName: `Second Site ${faker.location.city()}`,
+    latitude: '51.500000',
+    longitude: '-2.000000',
+    width: '30'
+  })
+
+  world.data.sites = [first, second]
+  return world.data.sites
+}
+
+export async function submitPrimaryAndWait(page) {
+  await page.locator('button[type="submit"]:not([name="analytics"])').click()
+  await page.waitForLoadState('load')
+}
+
+export async function expectReviewSiteDetailsPage(page) {
+  await expect(page.locator('h1').first()).toContainText(
+    'Review site details',
+    {
+      timeout: 30_000
+    }
+  )
+}
+
+export async function expectReviewSiteDetailsAnchor(page, siteNumber) {
+  await expectReviewSiteDetailsPage(page)
+  expect(page.url()).toContain(`#site-details-${siteNumber}`)
+}
+
+export function siteCardRow(page, key) {
+  return page.locator(
+    `#site-details-1 .govuk-summary-list__row:has(dt.govuk-summary-list__key:text-is("${key}"))`
+  )
+}
+
+export function siteCardRowValue(page, key) {
+  return siteCardRow(page, key).locator('.govuk-summary-list__value')
+}
+
+export function coordinateSystemLines(coordinateSystem) {
+  if (coordinateSystem === 'OSGB36') {
+    return ['OSGB36 (National Grid)', 'Eastings and Northings']
+  }
+  return ['WGS84 (World Geodetic System 1984)', 'Latitude and longitude']
+}
+
+export async function givenManualSite(world, siteType) {
+  if (siteType === 'polygon') {
+    await completeManualPolygonSite(world)
+  } else {
+    await completeManualCircleSite(world)
+  }
+  await expectReviewSiteDetailsPage(world.page)
+}
+
+export async function completeManualPolygonSite(world, options = {}) {
+  const {
+    siteName = `Polygon Cove ${faker.location.city()}`,
+    coordinateSystem = 'WGS84',
+    coordinates = [
+      { latitude: '50.000000', longitude: '-1.000000' },
+      { latitude: '50.001000', longitude: '-0.999000' },
+      { latitude: '50.000500', longitude: '-0.999500' }
+    ]
+  } = options
+
+  await loginAndReachTaskList(world)
+  await navigateToManualSiteEntry(world)
+
+  const page = world.page
+  await enterSiteName(page, siteName)
+  await page.waitForLoadState('load')
+  await selectCoordinatesEntryMethod(page, 'boundary')
+  await page.waitForLoadState('load')
+  await selectCoordinateSystem(page, coordinateSystem)
+  await page.waitForLoadState('load')
+
+  if (coordinateSystem === 'WGS84') {
+    await enterPolygonCoordinatesWGS84(page, coordinates)
+  } else {
+    await enterPolygonCoordinatesOSGB36(page, coordinates)
+  }
+  await page.waitForLoadState('load')
+
+  world.data.site = {
+    siteType: 'polygon',
+    siteName,
+    coordinateSystem,
+    coordinates
+  }
+  return world.data.site
 }
 
 export async function completeSiteDetailsViaFileUpload(

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -514,6 +514,60 @@ export async function givenManualSite(world, siteType) {
   await expectReviewSiteDetailsPage(world.page)
 }
 
+const COORDINATE_SYSTEM_RADIO = {
+  WGS84: '#coordinateSystem',
+  OSGB36: '#coordinateSystem-2'
+}
+
+export async function expectFieldPrePopulated(page, field, site) {
+  switch (field) {
+    case 'Site name':
+      await expect(page.locator('#siteName')).toHaveValue(site.siteName, {
+        timeout: 30_000
+      })
+      break
+    case 'Single or multiple sets of coordinates': {
+      const value = site.siteType === 'polygon' ? 'multiple' : 'single'
+      await expect(
+        page.locator(`input[name="coordinatesEntry"][value="${value}"]`)
+      ).toBeChecked({ timeout: 30_000 })
+      break
+    }
+    case 'Coordinate system':
+      await expect(
+        page.locator(COORDINATE_SYSTEM_RADIO[site.coordinateSystem])
+      ).toBeChecked({ timeout: 30_000 })
+      break
+    case 'Coordinates at centre of site':
+      await expect(page.locator('#latitude')).toHaveValue(site.latitude, {
+        timeout: 30_000
+      })
+      await expect(page.locator('#longitude')).toHaveValue(site.longitude, {
+        timeout: 30_000
+      })
+      break
+    case 'Width of circular site':
+      await expect(page.locator('#width')).toHaveValue(site.width, {
+        timeout: 30_000
+      })
+      break
+    case 'Start and end points':
+      await expect(page.locator('#coordinates-0-latitude')).toHaveValue(
+        site.coordinates[0].latitude,
+        { timeout: 30_000 }
+      )
+      await expect(page.locator('#coordinates-0-longitude')).toHaveValue(
+        site.coordinates[0].longitude,
+        { timeout: 30_000 }
+      )
+      break
+    default:
+      throw new Error(
+        `No pre-population assertion defined for field "${field}"`
+      )
+  }
+}
+
 export async function completeManualPolygonSite(world, options = {}) {
   const {
     siteName = `Polygon Cove ${faker.location.city()}`,


### PR DESCRIPTION
Review site details manual entry
display site details with its boundary coordinates
adding a second site shows it on the review page
Deleting a site that is not the last re-numbers the remaining sites
Deleting the last remaining site returns to the task list

This covers
ML-1239, ML-1203, ML-1204, ML-1202, ML-1200


