### PR TITLE
ML-1326 add Water Framework Directive journey tests 

### DIFF
--- a/test/features/lcml/lcml.apply.for.marine.licence.feature
+++ b/test/features/lcml/lcml.apply.for.marine.licence.feature
@@ -7,6 +7,7 @@ Feature: LCML: Apply for a marine licence
   Scenario: Organisation user can submit a marine licence with other authorities Yes and sharing consent Yes
     Given an organisation user has completed all tasks with special legal powers "Yes", other authorities "Yes" and sharing consent "Yes"
     And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    And the Water Framework Directive assessment task is completed
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
@@ -14,6 +15,7 @@ Feature: LCML: Apply for a marine licence
   Scenario: Intermediary user can submit a marine licence with other authorities No and sharing consent No
     Given an intermediary user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "No"
     And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    And the Water Framework Directive assessment task is completed
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page
@@ -21,6 +23,7 @@ Feature: LCML: Apply for a marine licence
   Scenario: Individual user can submit a marine licence with other authorities No and sharing consent No
     Given an individual user has completed all tasks with other authorities "No" and sharing consent "No"
     And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    And the Water Framework Directive assessment task is completed
     When the user submits the marine licence application from the task list
     Then the confirmation page is displayed with a marine licence reference
     And the submitted marine licence application is displayed on the projects page

--- a/test/features/lcml/lcml.water.framework.directive.feature
+++ b/test/features/lcml/lcml.water.framework.directive.feature
@@ -11,14 +11,6 @@ Feature: LCML: Water Framework Directive
     Then the "Water Framework Directive" section heading is displayed on the task list
     And the "Water Framework Directive assessment" task is displayed with status "Not yet started"
 
-  @issue=ML-1312
-  Scenario: Selecting the task displays the Before you start WFD page
-    Given an organisation user has started a marine licence application
-    When the user opens the Water Framework Directive assessment task
-    Then the Before you start WFD page is displayed with the project name in the caption
-    And the "Help with excluded activities" section is initially collapsed
-    And the guidance link opens the Water Framework Directive guidance on gov.uk in a new tab
-
   @issue=ML-1326
   Scenario: Selecting "No" on the One nautical mile page completes the WFD assessment task
     Given an organisation user is on the One nautical mile WFD page

--- a/test/features/lcml/lcml.water.framework.directive.feature
+++ b/test/features/lcml/lcml.water.framework.directive.feature
@@ -1,0 +1,27 @@
+@lcml @issue=ML-1312 @issue=ML-1326
+Feature: LCML: Water Framework Directive
+  As an applicant for a marine licence
+  I want to read about and complete the Water Framework Directive assessment
+  So that I understand whether my project needs a WFD assessment
+
+  @issue=ML-1312
+  Scenario: Water Framework Directive assessment task is displayed with "Not yet started"
+    Given an organisation user has started a marine licence application
+    When the user views the marine licence task list
+    Then the "Water Framework Directive" section heading is displayed on the task list
+    And the "Water Framework Directive assessment" task is displayed with status "Not yet started"
+
+  @issue=ML-1312
+  Scenario: Selecting the task displays the Before you start WFD page
+    Given an organisation user has started a marine licence application
+    When the user opens the Water Framework Directive assessment task
+    Then the Before you start WFD page is displayed with the project name in the caption
+    And the "Help with excluded activities" section is initially collapsed
+    And the guidance link opens the Water Framework Directive guidance on gov.uk in a new tab
+
+  @issue=ML-1326
+  Scenario: Selecting "No" on the One nautical mile page completes the WFD assessment task
+    Given an organisation user is on the One nautical mile WFD page
+    When the user selects "No" and continues on the One nautical mile page
+    Then the user is returned to the marine licence task list
+    And the "Water Framework Directive assessment" task is displayed with status "Completed"

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -10,6 +10,7 @@ import {
   completeSharingConsent,
   completeSiteDetailsViaFileUpload,
   completeProjectBackground,
+  completeWaterFrameworkDirective,
   pickRandomFileType
 } from '../support/lcml-helpers.js'
 
@@ -24,6 +25,7 @@ Given(
     await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
     await completeSiteDetailsViaFileUpload(this, pickRandomFileType())
+    await completeWaterFrameworkDirective(this.page)
   }
 )
 
@@ -38,6 +40,7 @@ Given(
     await completePublicConsultation(this.page)
     await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
+    await completeWaterFrameworkDirective(this.page)
   }
 )
 
@@ -51,6 +54,7 @@ Given(
     await completePublicConsultation(this.page)
     await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
+    await completeWaterFrameworkDirective(this.page)
   }
 )
 

--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -40,7 +40,6 @@ Given(
     await completePublicConsultation(this.page)
     await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
-    await completeWaterFrameworkDirective(this.page)
   }
 )
 
@@ -54,6 +53,12 @@ Given(
     await completePublicConsultation(this.page)
     await completePreferredDates(this.page)
     await completeSharingConsent(this.page, consentAnswer)
+  }
+)
+
+Given(
+  'the Water Framework Directive assessment task is completed',
+  async function () {
     await completeWaterFrameworkDirective(this.page)
   }
 )

--- a/test/steps/lcml.water.framework.directive.steps.js
+++ b/test/steps/lcml.water.framework.directive.steps.js
@@ -1,0 +1,102 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { loginAndStartApplication } from '../support/lcml-helpers.js'
+
+const TASK_LINK = 'Water Framework Directive assessment'
+const PAGE_PATH = '/marine-licence/water-framework-directive-before-you-start'
+const NAUTICAL_MILE_PATH =
+  '/marine-licence/water-framework-directive-nautical-mile'
+const GUIDANCE_URL =
+  'https://www.gov.uk/guidance/water-framework-directive-assessment-estuarine-and-coastal-waters'
+const NAUTICAL_MILE_RADIO_IDS = { Yes: '#nauticalMile', No: '#nauticalMile-2' }
+
+async function openWfdTask(page) {
+  await page.getByRole('link', { name: TASK_LINK }).click()
+  await page.waitForLoadState('load')
+}
+
+async function expectOnWfdPage(page) {
+  await expect(page).toHaveURL(new RegExp(PAGE_PATH), { timeout: 30_000 })
+  await expect(page.locator('main h1')).toContainText(
+    'Water Framework Directive',
+    {
+      timeout: 30_000
+    }
+  )
+  await expect(
+    page.getByRole('heading', { name: 'Before you start', level: 2 })
+  ).toBeVisible({ timeout: 30_000 })
+}
+
+When(
+  'the user opens the Water Framework Directive assessment task',
+  async function () {
+    await openWfdTask(this.page)
+  }
+)
+
+Then(
+  'the {string} section heading is displayed on the task list',
+  async function (heading) {
+    await expect(
+      this.page.getByRole('heading', { name: heading, level: 2, exact: true })
+    ).toBeVisible({ timeout: 30_000 })
+  }
+)
+
+Then(
+  'the Before you start WFD page is displayed with the project name in the caption',
+  async function () {
+    await expectOnWfdPage(this.page)
+    await expect(
+      this.page.locator('main .govuk-caption-l').first()
+    ).toContainText(this.data.projectName, { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the {string} section is initially collapsed',
+  async function (summaryText) {
+    const details = this.page.locator(
+      `details.govuk-details:has(summary:has-text("${summaryText}"))`
+    )
+    await expect(details).toBeVisible({ timeout: 30_000 })
+    expect(await details.evaluate((el) => el.open)).toBe(false)
+  }
+)
+
+Then(
+  'the guidance link opens the Water Framework Directive guidance on gov.uk in a new tab',
+  async function () {
+    const link = this.page.locator(
+      'main a:has-text("Read the guidance Water Framework Directive")'
+    )
+    await expect(link).toBeVisible({ timeout: 30_000 })
+    await expect(link).toHaveAttribute('href', GUIDANCE_URL, {
+      timeout: 30_000
+    })
+    await expect(link).toHaveAttribute('target', '_blank', { timeout: 30_000 })
+  }
+)
+
+Given(
+  'an organisation user is on the One nautical mile WFD page',
+  async function () {
+    await loginAndStartApplication(this, 'organisation')
+    await openWfdTask(this.page)
+    await this.page.locator('a.govuk-button:has-text("Continue")').click()
+    await this.page.waitForLoadState('load')
+    await expect(this.page).toHaveURL(new RegExp(NAUTICAL_MILE_PATH), {
+      timeout: 30_000
+    })
+  }
+)
+
+When(
+  'the user selects {string} and continues on the One nautical mile page',
+  async function (answer) {
+    await this.page.locator(NAUTICAL_MILE_RADIO_IDS[answer]).click()
+    await this.page.locator('main button[type="submit"]').click()
+    await this.page.waitForLoadState('load')
+  }
+)

--- a/test/steps/lcml.water.framework.directive.steps.js
+++ b/test/steps/lcml.water.framework.directive.steps.js
@@ -3,11 +3,8 @@ import { expect } from '@playwright/test'
 import { loginAndStartApplication } from '../support/lcml-helpers.js'
 
 const TASK_LINK = 'Water Framework Directive assessment'
-const PAGE_PATH = '/marine-licence/water-framework-directive-before-you-start'
 const NAUTICAL_MILE_PATH =
   '/marine-licence/water-framework-directive-nautical-mile'
-const GUIDANCE_URL =
-  'https://www.gov.uk/guidance/water-framework-directive-assessment-estuarine-and-coastal-waters'
 const NAUTICAL_MILE_RADIO_IDS = { Yes: '#nauticalMile', No: '#nauticalMile-2' }
 
 async function openWfdTask(page) {
@@ -15,67 +12,12 @@ async function openWfdTask(page) {
   await page.waitForLoadState('load')
 }
 
-async function expectOnWfdPage(page) {
-  await expect(page).toHaveURL(new RegExp(PAGE_PATH), { timeout: 30_000 })
-  await expect(page.locator('main h1')).toContainText(
-    'Water Framework Directive',
-    {
-      timeout: 30_000
-    }
-  )
-  await expect(
-    page.getByRole('heading', { name: 'Before you start', level: 2 })
-  ).toBeVisible({ timeout: 30_000 })
-}
-
-When(
-  'the user opens the Water Framework Directive assessment task',
-  async function () {
-    await openWfdTask(this.page)
-  }
-)
-
 Then(
   'the {string} section heading is displayed on the task list',
   async function (heading) {
     await expect(
       this.page.getByRole('heading', { name: heading, level: 2, exact: true })
     ).toBeVisible({ timeout: 30_000 })
-  }
-)
-
-Then(
-  'the Before you start WFD page is displayed with the project name in the caption',
-  async function () {
-    await expectOnWfdPage(this.page)
-    await expect(
-      this.page.locator('main .govuk-caption-l').first()
-    ).toContainText(this.data.projectName, { timeout: 30_000 })
-  }
-)
-
-Then(
-  'the {string} section is initially collapsed',
-  async function (summaryText) {
-    const details = this.page.locator(
-      `details.govuk-details:has(summary:has-text("${summaryText}"))`
-    )
-    await expect(details).toBeVisible({ timeout: 30_000 })
-    expect(await details.evaluate((el) => el.open)).toBe(false)
-  }
-)
-
-Then(
-  'the guidance link opens the Water Framework Directive guidance on gov.uk in a new tab',
-  async function () {
-    const link = this.page.locator(
-      'main a:has-text("Read the guidance Water Framework Directive")'
-    )
-    await expect(link).toBeVisible({ timeout: 30_000 })
-    await expect(link).toHaveAttribute('href', GUIDANCE_URL, {
-      timeout: 30_000
-    })
-    await expect(link).toHaveAttribute('target', '_blank', { timeout: 30_000 })
   }
 )
 

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -180,6 +180,21 @@ export async function completeProjectBackground(page, text) {
   await page.waitForLoadState('load')
 }
 
+export async function completeWaterFrameworkDirective(page, answer = 'No') {
+  await page
+    .locator('a:has-text("Water Framework Directive assessment")')
+    .click()
+  await page.waitForLoadState('load')
+  // "Before you start WFD" → "One nautical mile" question page
+  await page.locator('a.govuk-button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+  await page
+    .locator(answer === 'Yes' ? '#nauticalMile' : '#nauticalMile-2')
+    .click()
+  await page.locator('main button[type="submit"]').click()
+  await page.waitForLoadState('load')
+}
+
 export async function loginAndReachTaskList(world, role = 'organisation') {
   await loginAndStartApplication(world, role)
   await completeSpecialLegalPowers(world.page, 'No')


### PR DESCRIPTION
Water Framework Directive journey tests  added

covers ML-1312, ML-1326


Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/458
Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/723


