### PR TITLE
Ml 1306 iat context slug routing

### DIFF
--- a/test/features/iat/iat.intermediate.outcome.feature
+++ b/test/features/iat/iat.intermediate.outcome.feature
@@ -67,34 +67,14 @@ Feature: IAT: Intermediate outcome pages
       | Check to see if the activity is suitable for self-service marine licensing |
       | Apply for a standard marine licence                                        |
 
-  Scenario Outline: <route> intermediate outcome page renders via direct URL
-    Given the user navigates directly to the IAT outcome "<route>"
-    When the user views the IAT outcome page
-    Then the IAT intermediate outcome page "<route>" is displayed
-
-    Examples:
-      | route                         |
-      | /construction/journey-select  |
-      | /deposit/journey-select       |
-      | /removal/journey-select       |
-      | /dredging/journey-select      |
-
   Scenario Outline: Selecting "<option>" on <route> navigates to <expectedPath>
-    Given the user navigates directly to the IAT outcome "<route>"
+    Given the user walks the IAT to the outcome "<route>"
     When the user selects the "<option>" outcome option and clicks Continue
     Then the IAT lands on path "<expectedPath>"
 
     Examples:
-      | route                                              | option                                                                          | expectedPath                                          |
-      | /exemption/construction-exe-not-available-continue | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/construction/activity           |
-      | /exemption/deposit-exe-not-available-continue      | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/deposit/activity                |
-      | /exemption/removal-exe-not-available-continue      | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/removal/activity                |
-      | /exemption/dredging-exe-not-available-continue     | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/dredging/activity               |
-      | /construction/journey-select                       | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/construction          |
-      | /construction/journey-select                       | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/construction/activity           |
-      | /deposit/journey-select                            | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/deposit/activity-type |
-      | /deposit/journey-select                            | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/deposit/activity                |
-      | /removal/journey-select                            | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/removal/activity-type |
-      | /removal/journey-select                            | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/removal/activity                |
-      | /dredging/journey-select                           | Check to see if an exemption applies or notify the MMO about an exempt activity | /journey/self-service/exemption/dredging              |
-      | /dredging/journey-select                           | Check to see if the activity is suitable for self-service marine licensing      | /journey/self-service/dredging/activity               |
+      | route                                              | option                                                                     | expectedPath                                |
+      | /exemption/construction-exe-not-available-continue | Check to see if the activity is suitable for self-service marine licensing | /journey/self-service/construction/activity |
+      | /exemption/deposit-exe-not-available-continue      | Check to see if the activity is suitable for self-service marine licensing | /journey/self-service/deposit/activity      |
+      | /exemption/removal-exe-not-available-continue      | Check to see if the activity is suitable for self-service marine licensing | /journey/self-service/removal/activity      |
+      | /exemption/dredging-exe-not-available-continue     | Check to see if the activity is suitable for self-service marine licensing | /journey/self-service/dredging/activity     |

--- a/test/features/iat/iat.multi.select.feature
+++ b/test/features/iat/iat.multi.select.feature
@@ -5,20 +5,20 @@ Feature: IAT: Multi-select (checkbox) question pages
   So that I can pick one or more activities relevant to my project
 
   Scenario: Display a multi-select question page
-    Given an anonymous user navigates directly to the IAT question "/dredging/activities"
+    Given the user walks the IAT to the question "/dredging/activities"
     When the user views the IAT question page
     Then the IAT question page caption shows the section "Self-service check - Sub-activities" and heading contains "Please select sub-activites that match with activities proposed to be carried out."
     And the IAT question page shows checkboxes named "answers" with a Back link and a Continue button
     And the IAT question page has no header navigation links and any external guidance links open in a new tab
 
   Scenario: Selecting checkboxes and continuing navigates to the next question
-    Given an anonymous user navigates directly to the IAT question "/dredging/activities"
+    Given the user walks the IAT to the question "/dredging/activities"
     When the user selects the IAT checkbox "Non-navigational clearance dredging (for operational purposes)"
     And the user clicks the IAT Continue button
     Then the IAT question page URL has changed from "/dredging/activities"
 
   Scenario: Back link navigates away from the multi-select page with no answers pre-selected
-    Given an anonymous user navigates directly to the IAT question "/dredging/activities"
+    Given the user walks the IAT to the question "/dredging/activities"
     When the user clicks the IAT Back link
     Then the IAT question page URL has changed from "/dredging/activities"
     And no IAT checkbox is checked on the current question page

--- a/test/features/iat/iat.terminal.outcome.feature
+++ b/test/features/iat/iat.terminal.outcome.feature
@@ -5,14 +5,13 @@ Feature: IAT: Terminal outcome pages
   So that I can read the outcome and see a Continue button
 
   Scenario Outline: Terminal outcome page "<route>" renders heading, body and a Continue button
-    Given an anonymous user navigates directly to the IAT outcome "<route>"
+    Given the user walks the IAT to the outcome "<route>"
     When the user views the IAT outcome page
     Then the IAT terminal outcome page "<route>" is displayed with heading "<heading>"
     And the page has a body content block
     And the page has a placeholder Continue button
 
     Examples:
-      | route                                              | heading                                  |
-      | /fast-track-mla                                    | Self-service marine licensing            |
-      | /standard-marine-licence-application/construction  | Construction                             |
-      | /mod-permission                                    | MOD permission not sought or granted     |
+      | route           | heading                              |
+      | /fast-track-mla | Self-service marine licensing        |
+      | /mod-permission | MOD permission not sought or granted |

--- a/test/features/iat/iat.view.answers.feature
+++ b/test/features/iat/iat.view.answers.feature
@@ -5,8 +5,8 @@ Feature: IAT: Licence not required outcomes and viewing answers
   So that I know no marine licence is needed and can keep a copy of what I saw
 
   @issue=ML-1185
-  Scenario Outline: Anonymous user can view the "<route>" licence-not-required outcome page
-    Given an anonymous user navigates directly to the IAT outcome "<route>"
+  Scenario Outline: User reaches the "<route>" licence-not-required outcome by walking the IAT
+    Given the user walks the IAT to the outcome "<route>"
     When the user views the IAT outcome page
     Then the IAT licence-not-required outcome page "<route>" is displayed with heading "<heading>"
     And the page has a body content block
@@ -15,7 +15,6 @@ Feature: IAT: Licence not required outcomes and viewing answers
 
     Examples:
       | route                                              | heading                     |
-      | /exemption/licence-not-required                    | Marine licence not required |
       | /exemption/licence-not-required/sea                | Marine licence not required |
       | /exemption/licence-not-required/Activity-elsewhere | Marine licence not required |
       | /licence-not-required-devolved                     | Marine licence not required |
@@ -29,11 +28,11 @@ Feature: IAT: Licence not required outcomes and viewing answers
     Then the IAT licence-not-required outcome page "/exemption/licence-not-required/sea" is displayed with heading "Marine licence not required"
     And the page has a body content block
     And the page has a "View answers" link that opens in a new tab
-    And the Back link points to "/journey/self-service/sea"
+    And the Back link points to the first IAT question
 
   @issue=ML-1165
   Scenario: The View answers link is shown beneath the Continue button and opens in a new tab
-    Given an anonymous user navigates directly to the IAT outcome "/fast-track-mla"
+    Given the user walks the IAT to the outcome "/fast-track-mla"
     When the user views the IAT outcome page
     Then the page has a "View answers" link that opens in a new tab
     And the "View answers" link is displayed beneath the Continue button

--- a/test/steps/iat.intermediate.outcome.steps.js
+++ b/test/steps/iat.intermediate.outcome.steps.js
@@ -3,9 +3,11 @@ import { expect } from '@playwright/test'
 import { getConfig } from '../support/config.js'
 import {
   IAT_START_PATH,
-  OUTCOME_PREFIX,
-  navigateToOutcome
+  navigateToOutcome,
+  outcomeRegex,
+  landingPathRegex
 } from '../support/iat-outcome.js'
+import { walkToRoute } from '../support/iat-walk.js'
 
 async function answerByLabel(world, label) {
   // Match radio whose label text equals the supplied label, click it, take a
@@ -52,6 +54,18 @@ Given(
   }
 )
 
+// ML-1306: reach an outcome/question by walking the journey (no deep-links).
+Given('the user walks the IAT to the outcome {string}', async function (route) {
+  await walkToRoute(this, route)
+})
+
+Given(
+  'the user walks the IAT to the question {string}',
+  async function (route) {
+    await walkToRoute(this, route)
+  }
+)
+
 When('the user follows this IAT answer path:', async function (dataTable) {
   const answers = dataTable.hashes().map((row) => row.answer)
   for (const label of answers) {
@@ -90,12 +104,7 @@ When(
 Then(
   'the IAT intermediate outcome page {string} is displayed',
   async function (route) {
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        `${OUTCOME_PREFIX.replace(/\//g, '\\/')}${route.replace(/\//g, '\\/')}$`
-      ),
-      { timeout: 30_000 }
-    )
+    await expect(this.page).toHaveURL(outcomeRegex(route), { timeout: 30_000 })
     await expect(this.page.locator('h1').first()).toBeVisible({
       timeout: 30_000
     })
@@ -119,10 +128,9 @@ Then('the IAT outcome options include:', async function (dataTable) {
 })
 
 Then('the IAT lands on path {string}', async function (expectedPath) {
-  await expect(this.page).toHaveURL(
-    new RegExp(`${expectedPath.replace(/\//g, '\\/')}$`),
-    { timeout: 30_000 }
-  )
+  await expect(this.page).toHaveURL(landingPathRegex(expectedPath), {
+    timeout: 30_000
+  })
   if (this.attach) {
     this.attach(`redirected to -> ${expectedPath}`, 'text/plain')
   }

--- a/test/steps/iat.multi.select.steps.js
+++ b/test/steps/iat.multi.select.steps.js
@@ -1,6 +1,7 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { getConfig } from '../support/config.js'
+import { iatPathRegex } from '../support/iat-outcome.js'
 
 const QUESTION_PREFIX = '/journey/self-service'
 
@@ -110,13 +111,10 @@ Then(
 Then(
   'the IAT question page URL has changed from {string}',
   async function (originalRoute) {
-    // Anything but the original route is acceptable — proves navigation away.
-    await expect(this.page).not.toHaveURL(
-      new RegExp(
-        `${QUESTION_PREFIX.replace(/\//g, '\\/')}${originalRoute.replace(/\//g, '\\/')}$`
-      ),
-      { timeout: 30_000 }
-    )
+    // Anything but the original (slug-prefixed) route proves navigation away.
+    await expect(this.page).not.toHaveURL(iatPathRegex(originalRoute), {
+      timeout: 30_000
+    })
     if (this.attach) {
       this.attach(
         `navigated to -> ${new URL(this.page.url()).pathname}`,

--- a/test/steps/iat.terminal.outcome.steps.js
+++ b/test/steps/iat.terminal.outcome.steps.js
@@ -1,6 +1,6 @@
 import { Given, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
-import { OUTCOME_PREFIX, navigateToOutcome } from '../support/iat-outcome.js'
+import { navigateToOutcome, outcomeRegex } from '../support/iat-outcome.js'
 
 Given(
   'an anonymous user navigates directly to the IAT outcome {string}',
@@ -18,12 +18,7 @@ Given(
 Then(
   'the IAT terminal outcome page {string} is displayed with heading {string}',
   async function (route, heading) {
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        `${OUTCOME_PREFIX.replace(/\//g, '\\/')}${route.replace(/\//g, '\\/')}$`
-      ),
-      { timeout: 30_000 }
-    )
+    await expect(this.page).toHaveURL(outcomeRegex(route), { timeout: 30_000 })
     await expect(this.page.locator('h1').first()).toContainText(heading, {
       timeout: 30_000
     })

--- a/test/steps/iat.view.answers.steps.js
+++ b/test/steps/iat.view.answers.steps.js
@@ -1,9 +1,9 @@
 import { When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
-import { OUTCOME_PREFIX } from '../support/iat-outcome.js'
+import { outcomeRegex, iatPathRegex } from '../support/iat-outcome.js'
 
-const FIRST_QUESTION_PATH = '/journey/self-service/sea'
-const ANSWER_URL_PATTERN = /\/journey\/self-service\/answer\/[\w-]+$/
+const FIRST_QUESTION_REGEX = /\/journey\/self-service\/c\/[^/]+\/sea$/
+const ANSWER_URL_PATTERN = /\/journey\/self-service\/outcome-document\/[\w-]+$/
 
 Then(
   'the "View answers" link is displayed beneath the Continue button',
@@ -124,7 +124,7 @@ When(
   'the user goes back to the first IAT question and follows this answer path:',
   async function (dataTable) {
     const onFirstQuestion = () =>
-      new URL(this.page.url()).pathname === FIRST_QUESTION_PATH
+      FIRST_QUESTION_REGEX.test(new URL(this.page.url()).pathname)
     for (let i = 0; i < 10 && !onFirstQuestion(); i++) {
       const back = this.page.locator('a.govuk-back-link')
       if (!(await back.count())) break
@@ -146,12 +146,7 @@ When(
 Then(
   'the IAT licence-not-required outcome page {string} is displayed with heading {string}',
   async function (route, heading) {
-    await expect(this.page).toHaveURL(
-      new RegExp(
-        `${OUTCOME_PREFIX.replace(/\//g, '\\/')}${route.replace(/\//g, '\\/')}$`
-      ),
-      { timeout: 30_000 }
-    )
+    await expect(this.page).toHaveURL(outcomeRegex(route), { timeout: 30_000 })
     await expect(this.page.locator('h1').first()).toContainText(heading, {
       timeout: 30_000
     })
@@ -177,9 +172,9 @@ Then('the page has a Back link', async function () {
   expect(href).not.toBe('#')
 })
 
-Then('the Back link points to {string}', async function (expectedPath) {
+Then('the Back link points to the first IAT question', async function () {
   const back = this.page.locator('a.govuk-back-link', { hasText: 'Back' })
-  await expect(back.first()).toHaveAttribute('href', expectedPath, {
-    timeout: 30_000
-  })
+  const href = await back.first().getAttribute('href')
+  expect(href, 'Back link must have an href').toBeTruthy()
+  expect(href).toMatch(iatPathRegex('sea'))
 })

--- a/test/support/iat-outcome.js
+++ b/test/support/iat-outcome.js
@@ -1,6 +1,11 @@
 import { getConfig } from './config.js'
 
 export const IAT_START_PATH = '/journey/self-service/start'
+export const IAT_BASE = '/journey/self-service'
+
+// Retained for legacy direct-nav helpers (pre-ML-1306). Outcomes are no longer
+// anonymously deep-linkable, so these are only used by scenarios that are being
+// migrated to walk the journey.
 export const OUTCOME_PREFIX = '/journey/self-service/outcome'
 
 export function outcomeUrl(baseURL, route) {
@@ -14,4 +19,44 @@ export async function navigateToOutcome(world, route) {
   if (world.attach) {
     world.attach(`outcome page -> ${route}`, 'text/plain')
   }
+}
+
+// ML-1306: the IAT walkthrough now lives under a per-session context slug, e.g.
+//   /journey/self-service/c/{slug}/sea
+//   /journey/self-service/c/{slug}/outcome/{outcomePath}
+//   /journey/self-service/c/{slug}/view-answers/{outcomeTypeId}/{outcomePath}
+// The slug is a 22-char base64url id minted on POST /start.
+export const CONTEXT_SLUG = '[A-Za-z0-9_-]+'
+
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Regex matching a slug-prefixed IAT path. Pass the un-slugged path tail
+ * (everything after `/journey/self-service/`), e.g. `outcome/exemption/x` or
+ * `construction/activity`; it matches `…/c/{slug}/<tail>$`.
+ */
+export function iatPathRegex(tail) {
+  const clean = tail.replace(/^\//, '')
+  return new RegExp(
+    `${escapeForRegex(IAT_BASE)}\\/c\\/${CONTEXT_SLUG}\\/${escapeForRegex(clean)}$`
+  )
+}
+
+/** Regex for an outcome page: `…/c/{slug}/outcome/<route>$`. */
+export function outcomeRegex(route) {
+  return iatPathRegex(`outcome${route.startsWith('/') ? '' : '/'}${route}`)
+}
+
+/**
+ * Regex for a path the feature expresses as a full `/journey/self-service/<x>`
+ * path (e.g. the "lands on path" steps). Tolerates the inserted `/c/{slug}/`.
+ */
+export function landingPathRegex(fullPath) {
+  const tail = fullPath.replace(
+    new RegExp(`^${escapeForRegex(IAT_BASE)}\\/?`),
+    ''
+  )
+  return iatPathRegex(tail)
 }

--- a/test/support/iat-walk.js
+++ b/test/support/iat-walk.js
@@ -1,0 +1,153 @@
+import { getConfig } from './config.js'
+import { IAT_START_PATH } from './iat-outcome.js'
+
+export const IAT_PATHS = {
+  '/exemption/licence-not-required/sea': ['Somewhere else'],
+  '/licence-not-required-devolved': ['In or over the sea', 'Other UK waters'],
+  '/exemption/licence-not-required/Activity-elsewhere': [
+    'In or over the sea',
+    'Somewhere else in the world',
+    'Other'
+  ],
+  '/exemption/construction-exe-not-available-continue': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Construction',
+    'Build or make something new',
+    'Moorings or aids to navigation',
+    'Something else'
+  ],
+  '/exemption/deposit-exe-not-available-continue': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Deposit of a substance or object',
+    'From a vehicle or vessel',
+    'Fishing or shellfish propagation and cultivation',
+    'Something else'
+  ],
+  '/exemption/removal-exe-not-available-continue': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Removal of a substance or object',
+    'Using a vehicle or vessel',
+    'Yes',
+    'Fishing or shellfish propagation and cultivation',
+    'Something else'
+  ],
+  '/exemption/dredging-exe-not-available-continue': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Dredging',
+    'Something else'
+  ],
+  '/fast-track-mla': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Deposit of a substance or object',
+    'From a vehicle or vessel',
+    'Fishing or shellfish propagation and cultivation',
+    'Something else',
+    'Check to see if the activity is suitable for self-service marine licensing',
+    'Burial at Sea',
+    'Yes',
+    'Needles, Isle of Wight',
+    'Yes'
+  ],
+  '/dredging/activities': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Dredging',
+    'Something else',
+    'Check to see if the activity is suitable for self-service marine licensing',
+    'Non-navigational clearance dredging'
+  ],
+
+  '/mod-permission': [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Dredging',
+    'Something else',
+    'Check to see if the activity is suitable for self-service marine licensing',
+    'Non-navigational clearance dredging',
+    'Non-navigational clearance dredging (for operational purposes)',
+    'Yes',
+    'No',
+    'No',
+    'Yes',
+    'Yes',
+    'No',
+    'No'
+  ]
+}
+
+/**
+ * Follow one step of an IAT path. The label is either a single-select radio
+ * answer or an intermediate-outcome fork option heading.
+ */
+export async function followIatStep(page, label) {
+  const radio = page
+    .locator('label.govuk-radios__label', { hasText: label })
+    .first()
+  if (await radio.count()) {
+    await radio.click()
+    await page.locator('button:has-text("Continue")').first().click()
+    await page.waitForLoadState('load')
+    return
+  }
+  const checkbox = page
+    .locator('.govuk-checkboxes__item', {
+      has: page.locator('label', { hasText: label })
+    })
+    .locator('input[type="checkbox"]')
+    .first()
+  if (await checkbox.count()) {
+    await checkbox.check()
+    await page.locator('button:has-text("Continue")').first().click()
+    await page.waitForLoadState('load')
+    return
+  }
+  const option = page
+    .locator('.app-iat-option', {
+      has: page.locator('h2', { hasText: label })
+    })
+    .first()
+  if (await option.count()) {
+    await option
+      .locator('button:has-text("Continue"), a:has-text("Continue")')
+      .first()
+      .click()
+    await page.waitForLoadState('load')
+    return
+  }
+  throw new Error(`IAT path step not found on page: "${label}"`)
+}
+
+export async function startIat(world) {
+  const config = getConfig()
+  await world.page.goto(new URL(IAT_START_PATH, config.baseURL).toString())
+  await world.page.waitForLoadState('load')
+  await world.page
+    .locator(
+      'a.govuk-button:has-text("Start now"), button:has-text("Start now")'
+    )
+    .click()
+  await world.page.waitForLoadState('load')
+}
+
+export async function walkIatPath(world, labels) {
+  await startIat(world)
+  for (const label of labels) {
+    await followIatStep(world.page, label)
+  }
+}
+
+export async function walkToRoute(world, route) {
+  const labels = IAT_PATHS[route]
+  if (!labels) {
+    throw new Error(`No known IAT answer path for route "${route}"`)
+  }
+  await walkIatPath(world, labels)
+  if (world.attach) {
+    world.attach(`walked IAT to -> ${route}`, 'text/plain')
+  }
+}


### PR DESCRIPTION
Updating the IAT journey test to handle the context slug


Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/715
Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/451



