### PR TITLE
Fix DEFRA ID stub registration failures in Docker Compose CI

### DIFF
--- a/compose.common.yml
+++ b/compose.common.yml
@@ -17,6 +17,8 @@ services:
     ports:
       - '3200:3200'
     restart: unless-stopped
+    env_file:
+      - compose/aws.env
     environment:
       PORT: 3200
       REDIS_HOST: redis-frontend
@@ -24,8 +26,15 @@ services:
       USE_SINGLE_INSTANCE_CACHE: true
       NODE_ENV: development
       APP_BASE_URL: ${DEFRA_ID_APP_BASE_URL:-http://defra-id-stub:3200}
+      REGISTRATIONS_STORE_ENGINE: dynamodb
+      REGISTRATIONS_STORE_TTL: 259200000
+      AWS_DYNAMODB_REGISTRATIONS_TABLE_NAME: cdp-defra-id-stub-registrations
+      DYNAMODB_ENDPOINT: http://localstack:4566
+      AWS_REGION: eu-west-2
     depends_on:
       redis-frontend:
+        condition: service_healthy
+      localstack:
         condition: service_healthy
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3200/health']
@@ -85,7 +94,7 @@ services:
     environment:
       DEBUG: ${DEBUG:-1}
       LS_LOG: WARN # Localstack DEBUG Level
-      SERVICES: s3,sqs,sns,firehose
+      SERVICES: s3,sqs,sns,firehose,dynamodb
       LOCALSTACK_HOST: 127.0.0.1
     volumes:
       - '${TMPDIR:-/tmp}/localstack:/var/lib/localstack'

--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,8 @@ services:
     ports:
       - '3200:3200'
     restart: unless-stopped
+    env_file:
+      - compose/aws.env
     environment:
       PORT: 3200
       REDIS_HOST: redis-frontend
@@ -31,8 +33,15 @@ services:
       SESSION_CACHE_NAME: defraIdStubSession
       NODE_ENV: development
       APP_BASE_URL: ${DEFRA_ID_APP_BASE_URL:-http://defra-id-stub:3200}
+      REGISTRATIONS_STORE_ENGINE: dynamodb
+      REGISTRATIONS_STORE_TTL: 259200000
+      AWS_DYNAMODB_REGISTRATIONS_TABLE_NAME: cdp-defra-id-stub-registrations
+      DYNAMODB_ENDPOINT: http://localstack:4566
+      AWS_REGION: eu-west-2
     depends_on:
       redis-frontend:
+        condition: service_healthy
+      localstack:
         condition: service_healthy
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3200/health']
@@ -92,7 +101,7 @@ services:
     environment:
       DEBUG: ${DEBUG:-1}
       LS_LOG: WARN # Localstack DEBUG Level
-      SERVICES: s3,sqs,sns,firehose
+      SERVICES: s3,sqs,sns,firehose,dynamodb
       LOCALSTACK_HOST: 127.0.0.1
     volumes:
       - '${TMPDIR:-/tmp}/localstack:/var/lib/localstack'

--- a/compose/start-localstack.sh
+++ b/compose/start-localstack.sh
@@ -38,3 +38,27 @@ aws --endpoint-url=http://localhost:4566 s3api put-bucket-notification-configura
 # Fix multiple errors per second - this is probably the cdp-uploader test harness leakage.
 # We can add this in here - as compose is only used for local dev.
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name cdp-uploader-download-requests
+
+# DEFRA ID stub registrations (DynamoDB)
+table_name="${AWS_DYNAMODB_REGISTRATIONS_TABLE_NAME:-cdp-defra-id-stub-registrations}"
+
+if aws --endpoint-url=http://localhost:4566 dynamodb describe-table --table-name "$table_name" >/dev/null 2>&1; then
+  echo "Table '$table_name' already exists"
+else
+  aws --endpoint-url=http://localhost:4566 dynamodb create-table \
+    --table-name "$table_name" \
+    --attribute-definitions \
+      AttributeName=pk,AttributeType=S \
+      AttributeName=sk,AttributeType=S \
+    --key-schema \
+      AttributeName=pk,KeyType=HASH \
+      AttributeName=sk,KeyType=RANGE \
+    --billing-mode PAY_PER_REQUEST
+  echo "Created table '$table_name'"
+fi
+
+aws --endpoint-url=http://localhost:4566 dynamodb update-time-to-live \
+  --table-name "$table_name" \
+  --time-to-live-specification "Enabled=true,AttributeName=expiresAt"
+
+echo "Enabled TTL on '$table_name' using expiresAt"


### PR DESCRIPTION
Configure defra-id-stub for DynamoDB-backed registrations after cdp-defra-id-stub moved off Redis. Enable dynamodb in LocalStack, create the registrations table on startup, and point the stub at http://localstack:4566 so test user registration succeeds again.

