### PR TITLE
ML-1288 Trying to create new exemption just changes name of existing exemption

### DIFF
--- a/test/features/exemptions/mcms.context.validation.feature
+++ b/test/features/exemptions/mcms.context.validation.feature
@@ -10,6 +10,14 @@ Feature: MCMS context validation: MCMS context is validated and handled correctl
     When all tasks are completed for a circular site using WGS84 coordinates and review and send is clicked
     Then the project summary card is displayed in full on the check your answers page
 
+  @issue=ML-1288
+  Scenario: Starting a second exemption via IAT URL mid-draft creates a new notification without renaming the first
+    Given a user has a draft exemption on the review site details page with sites and public register completed
+    When the user opens the pre-canned IAT URL again in the same session
+    And entering and saving a project with a valid name for the second exemption
+    Then the dashboard shows both exemption project names
+    And the first exemption retains its original project name
+
   @issue=ML-948 @issue=ML-882
   Scenario: Missing MCMS context prevents notification creation and redirects user to projects dashboard
     Given a notification is started with MCMS context ""

--- a/test/steps/mcms.context.validation.steps.js
+++ b/test/steps/mcms.context.validation.steps.js
@@ -104,10 +104,13 @@ When(
   }
 )
 
-When('the user opens the pre-canned IAT URL again in the same session', async function () {
-  this.data.iatContext = this.data.firstIatContext
-  await openIatHandoffUrlInSameSession(this, { useRootPath: true })
-})
+When(
+  'the user opens the pre-canned IAT URL again in the same session',
+  async function () {
+    this.data.iatContext = this.data.firstIatContext
+    await openIatHandoffUrlInSameSession(this, { useRootPath: true })
+  }
+)
 
 When(
   'entering and saving a project with a valid name for the second exemption',
@@ -227,12 +230,15 @@ Then('the dashboard shows both exemption project names', async function () {
   }
 })
 
-Then('the first exemption retains its original project name', async function () {
-  const dashboard = new DashboardPage(this.page)
-  const row = await dashboard.getNotificationRow(this.data.firstProjectName)
-  expect(row.name).toBe(this.data.firstProjectName)
-  expect(row.status).toBe('Draft')
-})
+Then(
+  'the first exemption retains its original project name',
+  async function () {
+    const dashboard = new DashboardPage(this.page)
+    const row = await dashboard.getNotificationRow(this.data.firstProjectName)
+    expect(row.name).toBe(this.data.firstProjectName)
+    expect(row.status).toBe('Draft')
+  }
+)
 
 When('the project name page is visited', async function () {
   const config = getConfig()

--- a/test/steps/mcms.context.validation.steps.js
+++ b/test/steps/mcms.context.validation.steps.js
@@ -1,18 +1,32 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
-import { createCYACircleWGS84Data } from '../test-data/check-your-answers.js'
-import { generateIatContext } from '../test-data/exemption.js'
+import {
+  createCYACircleWGS84Data,
+  withPublicRegister
+} from '../test-data/check-your-answers.js'
+import {
+  generateIatContext,
+  generateProjectName
+} from '../test-data/exemption.js'
+import { createMixedMultiSiteData } from '../test-data/site-details.js'
 import {
   completeAllTasks,
   clickReviewAndSend,
   completeTasksFromCurrentPage
 } from '../support/task-flow.js'
+import { completeSiteDetailsFlow } from '../support/site-details-flow.js'
 import {
   navigateAndAuthenticate,
-  navigateWithRawQueryString
+  navigateWithRawQueryString,
+  openIatHandoffUrlInSameSession
 } from '../support/navigation.js'
 import { getConfig } from '../support/config.js'
 import CheckYourAnswersPage from '../pages/check.your.answers.page.js'
+import ProjectNamePage from '../pages/project.name.page.js'
+import TaskListPage from '../pages/task.list.page.js'
+import PublicRegisterPage from '../pages/public.register.page.js'
+import DashboardPage from '../pages/dashboard.page.js'
+import CommonElementsPage from '../pages/common.elements.page.js'
 
 Given(
   'a second notification is started with valid MCMS context after completing a first notification',
@@ -36,6 +50,43 @@ Given(
 )
 
 Given(
+  'a user has a draft exemption on the review site details page with sites and public register completed',
+  async function () {
+    this.data = withPublicRegister(
+      createMixedMultiSiteData({
+        sameActivityDates: true,
+        sameActivityDescription: true
+      })
+    )
+
+    await navigateAndAuthenticate(this, '/')
+
+    const projectPage = new ProjectNamePage(this.page)
+    await projectPage.enterProjectName(this.data.projectName)
+    this.data.firstProjectName = this.data.projectName
+    this.data.firstIatContext = this.data.iatContext
+    this.data.projectNameTaskCompleted = true
+
+    const taskList = new TaskListPage(this.page)
+    await taskList.selectTask('Site details')
+    await completeSiteDetailsFlow(this.page, this.data.siteDetails)
+    await this.page.locator('button:has-text("Continue")').click()
+    await this.page.waitForLoadState('load')
+
+    await taskList.selectTask('Sharing your project information publicly')
+    const publicRegister = new PublicRegisterPage(this.page)
+    await publicRegister.completeAndSave(
+      this.data.publicRegister.consent,
+      this.data.publicRegister.reason
+    )
+
+    await taskList.selectTask('Site details')
+    const common = new CommonElementsPage(this.page)
+    await common.expectHeading('Review site details')
+  }
+)
+
+Given(
   'a notification is started with MCMS context {string}',
   async function (iatQueryString) {
     this.data = createCYACircleWGS84Data()
@@ -50,6 +101,20 @@ When(
   async function () {
     await completeTasksFromCurrentPage(this)
     await clickReviewAndSend(this.page)
+  }
+)
+
+When('the user opens the pre-canned IAT URL again in the same session', async function () {
+  this.data.iatContext = this.data.firstIatContext
+  await openIatHandoffUrlInSameSession(this, { useRootPath: true })
+})
+
+When(
+  'entering and saving a project with a valid name for the second exemption',
+  async function () {
+    this.data.secondProjectName = generateProjectName()
+    const projectPage = new ProjectNamePage(this.page)
+    await projectPage.enterProjectName(this.data.secondProjectName)
   }
 )
 
@@ -129,6 +194,45 @@ Then(
     ).not.toBeVisible()
   }
 )
+
+Then('the dashboard shows both exemption project names', async function () {
+  const dashboard = new DashboardPage(this.page)
+  await dashboard.clickProjectsLink()
+  await dashboard.expectIsDisplayed()
+
+  const notifications = await dashboard.getNotifications()
+  const namesOnDashboard = notifications.map((n) => n.name)
+  const expectedNames = [
+    this.data.firstProjectName,
+    this.data.secondProjectName
+  ]
+
+  this.attach(
+    JSON.stringify(
+      {
+        expectedProjectNames: expectedNames,
+        projectNamesOnDashboard: namesOnDashboard
+      },
+      null,
+      2
+    ),
+    'application/json'
+  )
+
+  for (const name of expectedNames) {
+    expect(
+      namesOnDashboard,
+      `Expected "${name}" on the projects dashboard. Found: ${namesOnDashboard.join(', ') || 'no projects'}`
+    ).toContain(name)
+  }
+})
+
+Then('the first exemption retains its original project name', async function () {
+  const dashboard = new DashboardPage(this.page)
+  const row = await dashboard.getNotificationRow(this.data.firstProjectName)
+  expect(row.name).toBe(this.data.firstProjectName)
+  expect(row.status).toBe('Draft')
+})
 
 When('the project name page is visited', async function () {
   const config = getConfig()

--- a/test/support/navigation.js
+++ b/test/support/navigation.js
@@ -97,6 +97,21 @@ export async function navigateAndReAuthenticate(world, targetPath) {
   await acceptCookies(world.page)
 }
 
+/**
+ * Re-open the pre-canned IAT handoff URL while already logged in (same tab/session).
+ * Matches manual testing: paste the same root URL with IAT query params from an in-progress page.
+ * Does not re-register the test user or repeat the OIDC stub login flow.
+ */
+export async function openIatHandoffUrlInSameSession(world, options = {}) {
+  const config = getConfig()
+  const basePath = options.useRootPath ? '/' : GUIDANCE_PATH
+  const url = buildNavigationUrl(basePath, world.data.iatContext)
+  await world.page.goto(new URL(url, config.baseURL).toString())
+  await world.page.waitForLoadState('load')
+  await selectGuidanceOptionAndContinueIfPresent(world.page, 5_000)
+  await handleConfirmEmployeePageIfPresent(world.page)
+}
+
 export async function navigateWithRawQueryString(
   world,
   targetPath,


### PR DESCRIPTION
## Description

Adds a journey test for ML-1288: starting a second exemption via the pre-canned IAT URL while the first is still a mid-draft, without renaming the first project.

- New scenario in mcms.context.validation.feature covering review site details → re-open IAT URL → second project name → both names on dashboard

- New openIatHandoffUrlInSameSession helper to match manual testing (same root URL, same session, no re-login)

- Step definitions to set up a draft with sites and public register, then assert both exemptions appear on the projects page
