### PR TITLE
ML-1166 ML-1299 IAT exemption handoff context and IAT answers link tests

### DIFF
--- a/docker/config/defaults.env
+++ b/docker/config/defaults.env
@@ -6,6 +6,8 @@ Mongo__DatabaseUri=mongodb://mongodb:27017/?tls=false
 REDIS_HOST=redis
 USE_SINGLE_INSTANCE_CACHE=true
 
+FRONTEND_BASE_URL=http://marine-licensing-frontend:3000
+
 # Localstack/AWS
 LOCALSTACK_URL=http://localstack:4566
 SNS_ENDPOINT=http://localstack:4566

--- a/test/features/iat/iat.exemption.handoff.feature
+++ b/test/features/iat/iat.exemption.handoff.feature
@@ -1,0 +1,57 @@
+@iat
+Feature: IAT: passing context into the exemption journey
+  As an applicant who reaches an exemption terminal outcome in the IAT
+  I want the Continue button to carry my IAT context into the exemption journey
+  So that my exemption notification is pre-populated from my IAT answers
+
+  @issue=ML-1166
+  Scenario Outline: Continue from a <activityType> exemption outcome carries the IAT context in the query string
+    Given the user walks the IAT to an exemption handoff outcome for "<activityType>"
+    When the user follows the exemption Continue button
+    Then the exemption journey URL contains the IAT context parameters
+      | parameter      | value          |
+      | ACTIVITY_TYPE  | <activityType> |
+      | <subtypeParam> | <subtype>      |
+      | ADV_TYPE       | EXE            |
+      | ARTICLE        | <article>      |
+
+    Examples:
+      | activityType | subtypeParam                      | subtype                           | article |
+      | CON          | EXE_ACTIVITY_SUBTYPE_CONSTRUCTION | new                               | 20      |
+      | DEPOSIT      | EXE_ACTIVITY_SUBTYPE_DEPOSIT      | emergency                         | 20      |
+      | REMOVAL      | EXE_ACTIVITY_SUBTYPE_REMOVAL      | markersMooringsAndAidToNavigation | 26A     |
+      | DREDGE       | EXE_ACTIVITY_SUBTYPE_DREDGING     | shellfish                         | 13      |
+
+  @issue=ML-1166 @issue=ML-1299
+  Scenario Outline: The <activityType> check your answers page links to the IAT answers
+    Given the user walks the IAT to an exemption handoff outcome for "<activityType>"
+    And the user follows the exemption Continue button
+    And the user signs in and completes the exemption journey
+    When the user opens the View answers link on the check your answers page
+    Then the answers page shows the "<activity>" activity
+
+    Examples:
+      | activityType | activity                         |
+      | CON          | Construction                     |
+      | DEPOSIT      | Deposit of a substance or object |
+      | REMOVAL      | Removal of a substance or object |
+      | DREDGE       | Dredging                         |
+
+  @issue=ML-1299
+  Scenario: View details opens the IAT answers page with print and save as PDF options
+    Given the user walks the IAT to an exemption handoff outcome for "DREDGE"
+    And the user follows the exemption Continue button
+    And the user signs in and submits the exemption
+    And the user clicks view details for the submitted notification on the dashboard
+    When the user opens the View answers link from the View details page
+    Then the IAT answers page provides print and save as PDF options
+
+  @fivium @issue=ML-1299
+  Scenario: A Fivium-sourced exemption offers a downloadable PDF of the answers
+    Given the user walks the Fivium IAT to an exemption handoff outcome
+    And the user follows the exemption Continue button
+    And the user signs in and completes the exemption journey
+    And the check your answers page offers a downloadable PDF copy
+    And the user submits the exemption
+    When the user clicks view details for the submitted notification on the dashboard
+    Then the answers link offers a downloadable PDF copy

--- a/test/features/iat/iat.exemption.handoff.feature
+++ b/test/features/iat/iat.exemption.handoff.feature
@@ -46,7 +46,7 @@ Feature: IAT: passing context into the exemption journey
     When the user opens the View answers link from the View details page
     Then the IAT answers page provides print and save as PDF options
 
-  @fivium @issue=ML-1299
+  @fivium @real-defra-id @issue=ML-1299
   Scenario: A Fivium-sourced exemption offers a downloadable PDF of the answers
     Given the user walks the Fivium IAT to an exemption handoff outcome
     And the user follows the exemption Continue button

--- a/test/steps/iat.exemption.handoff.steps.js
+++ b/test/steps/iat.exemption.handoff.steps.js
@@ -1,0 +1,199 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import {
+  GUIDANCE_PATH,
+  authenticateFromGuidancePage
+} from '../support/navigation.js'
+import {
+  completeTasksFromCurrentPage,
+  submitNotificationFromCurrentPage,
+  submitCompletedExemption
+} from '../support/task-flow.js'
+import { createCYACircleWGS84Data } from '../test-data/check-your-answers.js'
+import { getConfig } from '../support/config.js'
+import {
+  EXEMPTION_HANDOFF_PATHS,
+  FIVIUM_IAT_START_URL,
+  walkIatPath
+} from '../support/iat-walk.js'
+
+const EXEMPTION_GUIDANCE_RE = new RegExp(
+  GUIDANCE_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+)
+
+Given(
+  'the user walks the IAT to an exemption handoff outcome for {string}',
+  async function (activityType) {
+    const labels = EXEMPTION_HANDOFF_PATHS[activityType]
+    if (!labels) {
+      throw new Error(
+        `No exemption-handoff IAT path for activity type "${activityType}"`
+      )
+    }
+    await walkIatPath(this, labels)
+  }
+)
+
+When('the user follows the exemption Continue button', async function () {
+  await expect(this.page).toHaveURL(/\/outcome\//, { timeout: 30_000 })
+  const continueButton = this.page
+    .locator(
+      'main a.govuk-button:has-text("Continue"), main button.govuk-button:has-text("Continue")'
+    )
+    .first()
+  await expect(continueButton).toBeVisible({ timeout: 30_000 })
+  await continueButton.click()
+  await this.page.waitForURL(EXEMPTION_GUIDANCE_RE, { timeout: 30_000 })
+  await this.page.waitForLoadState('load')
+})
+
+Then(
+  'the exemption journey URL contains the IAT context parameters',
+  async function (dataTable) {
+    const params = new URL(this.page.url()).searchParams
+    for (const { parameter, value } of dataTable.hashes()) {
+      expect(params.get(parameter), `query param ${parameter}`).toBe(value)
+    }
+  }
+)
+
+Given(
+  'the user signs in and completes the exemption journey',
+  async function () {
+    await authenticateFromGuidancePage(this)
+    this.data = createCYACircleWGS84Data()
+    await completeTasksFromCurrentPage(this)
+  }
+)
+
+When(
+  'the user opens the View answers link on the check your answers page',
+  async function () {
+    const config = getConfig()
+    await this.page.goto(
+      new URL('/exemption/check-your-answers', config.baseURL).toString()
+    )
+    await this.page.waitForLoadState('load')
+
+    const viewAnswersLink = this.page
+      .locator('main a', { hasText: 'View answers (opens in a new tab)' })
+      .first()
+    await expect(viewAnswersLink).toBeVisible({ timeout: 30_000 })
+    expect(await viewAnswersLink.getAttribute('target')).toBe('_blank')
+
+    const href = await viewAnswersLink.getAttribute('href')
+    expect(href, 'View answers link href').toMatch(/outcome-document/)
+    if (this.attach) {
+      this.attach(`answers URL -> ${href}`, 'text/plain')
+    }
+
+    await this.page.goto(href)
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then('the answers page shows the {string} activity', async function (activity) {
+  await expect(
+    this.page
+      .locator('h1, h2', { hasText: 'Marine licence requirement check' })
+      .first()
+  ).toBeVisible({ timeout: 30_000 })
+
+  await expect(
+    this.page
+      .locator('.govuk-summary-list__value', { hasText: activity })
+      .first()
+  ).toBeVisible({ timeout: 30_000 })
+})
+
+Given('the user signs in and submits the exemption', async function () {
+  await authenticateFromGuidancePage(this)
+  this.data = createCYACircleWGS84Data()
+  await submitNotificationFromCurrentPage(this)
+})
+
+When(
+  'the user opens the View answers link from the View details page',
+  async function () {
+    const viewAnswersLink = this.page
+      .locator('main a', { hasText: 'View answers (opens in a new tab)' })
+      .first()
+    await expect(viewAnswersLink).toBeVisible({ timeout: 30_000 })
+    expect(await viewAnswersLink.getAttribute('target')).toBe('_blank')
+    expect(await viewAnswersLink.getAttribute('href')).toMatch(
+      /outcome-document/
+    )
+
+    const popupPromise = this.page.waitForEvent('popup')
+    await viewAnswersLink.click()
+    const answersPage = await popupPromise
+    await answersPage.waitForLoadState('load')
+    this.answersPage = answersPage
+  }
+)
+
+Then(
+  'the IAT answers page provides print and save as PDF options',
+  async function () {
+    const page = this.answersPage
+    await expect(page.locator('h1').first()).toContainText(
+      'Marine licence requirement check',
+      { timeout: 30_000 }
+    )
+
+    const printLink = page.locator('.print-link')
+    await expect(printLink).toBeVisible({ timeout: 30_000 })
+    await expect(printLink).toHaveText(/Print this page/)
+
+    await expect(page.locator('.print-instructions')).toContainText(
+      'Save as PDF',
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Given(
+  'the user walks the Fivium IAT to an exemption handoff outcome',
+  async function () {
+    await walkIatPath(
+      this,
+      EXEMPTION_HANDOFF_PATHS.DREDGE,
+      FIVIUM_IAT_START_URL
+    )
+  }
+)
+
+async function expectDownloadablePdfAnswersLink(page) {
+  const pdfLink = page
+    .locator('main a', { hasText: 'Download a copy of your answers (PDF)' })
+    .first()
+  await expect(pdfLink).toBeVisible({ timeout: 30_000 })
+  expect(await pdfLink.getAttribute('href')).toContain(
+    'marinemanagement.org.uk'
+  )
+}
+
+Given(
+  'the check your answers page offers a downloadable PDF copy',
+  async function () {
+    const config = getConfig()
+    await this.page.goto(
+      new URL('/exemption/check-your-answers', config.baseURL).toString()
+    )
+    await this.page.waitForLoadState('load')
+    await expectDownloadablePdfAnswersLink(this.page)
+  }
+)
+
+Given('the user submits the exemption', async function () {
+  const config = getConfig()
+  await this.page.goto(
+    new URL('/exemption/task-list', config.baseURL).toString()
+  )
+  await this.page.waitForLoadState('load')
+  await submitCompletedExemption(this)
+})
+
+Then('the answers link offers a downloadable PDF copy', async function () {
+  await expectDownloadablePdfAnswersLink(this.page)
+})

--- a/test/support/iat-walk.js
+++ b/test/support/iat-walk.js
@@ -80,6 +80,45 @@ export const IAT_PATHS = {
   ]
 }
 
+export const EXEMPTION_HANDOFF_PATHS = {
+  CON: [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Construction',
+    'Build or make something new',
+    'Flood or flood risk',
+    'Yes',
+    'Yes'
+  ],
+  DEPOSIT: [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Deposit of a substance or object',
+    'From a vehicle or vessel',
+    'Emergency or safety and training',
+    'Flood or flood risk',
+    'Yes',
+    'Yes'
+  ],
+  REMOVAL: [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Removal of a substance or object',
+    'Using a vehicle or vessel',
+    'Yes',
+    'Markers, moorings or aids to navigation',
+    'Temporary markers',
+    'Removal of a marker that has been in place for 24 hours to 28 days where the Marine Management Organisation was already notified'
+  ],
+  DREDGE: [
+    'In or over the sea',
+    'English waters or Northern Ireland offshore waters',
+    'Dredging',
+    'Shellfish propagation and cultivation',
+    'Yes'
+  ]
+}
+
 /**
  * Follow one step of an IAT path. The label is either a single-select radio
  * answer or an intermediate-outcome fork option heading.
@@ -122,9 +161,15 @@ export async function followIatStep(page, label) {
   throw new Error(`IAT path step not found on page: "${label}"`)
 }
 
-export async function startIat(world) {
+export const FIVIUM_IAT_START_URL =
+  process.env.IAT_URL ||
+  process.env.FIVIUM_IAT_START_URL ||
+  'https://marinelicensingtest.marinemanagement.org.uk/mmofox5uat/journey/self-service/start'
+
+export async function startIat(world, startUrl) {
   const config = getConfig()
-  await world.page.goto(new URL(IAT_START_PATH, config.baseURL).toString())
+  const url = startUrl || new URL(IAT_START_PATH, config.baseURL).toString()
+  await world.page.goto(url)
   await world.page.waitForLoadState('load')
   await world.page
     .locator(
@@ -134,8 +179,8 @@ export async function startIat(world) {
   await world.page.waitForLoadState('load')
 }
 
-export async function walkIatPath(world, labels) {
-  await startIat(world)
+export async function walkIatPath(world, labels, startUrl) {
+  await startIat(world, startUrl)
   for (const label of labels) {
     await followIatStep(world.page, label)
   }

--- a/test/support/navigation.js
+++ b/test/support/navigation.js
@@ -8,7 +8,7 @@ import {
 } from './auth.js'
 import { buildNavigationUrl } from '../test-data/exemption.js'
 
-const GUIDANCE_PATH = '/guidance/who-is-the-exemption-for'
+export const GUIDANCE_PATH = '/guidance/who-is-the-exemption-for'
 
 async function selectGuidanceOptionAndContinueIfPresent(
   page,
@@ -36,23 +36,13 @@ async function handleConfirmEmployeePageIfPresent(page) {
   }
 }
 
-export async function navigateAndAuthenticate(world, targetPath, options = {}) {
+export async function authenticateFromGuidancePage(world, options = {}) {
   const config = getConfig()
 
-  if (!world.data?.iatContext) {
-    throw new Error(
-      'Test data must include iatContext before navigating. ' +
-        'Call a test data factory (e.g. createValidProjectNameData) first.'
-    )
-  }
-
-  // Register user BEFORE navigating so the authorize page includes their login link
   if (!config.isRealDefraId && !world.testUser) {
     world.testUser = await registerTestUser(config.defraIdUrl)
   }
 
-  const url = buildNavigationUrl(GUIDANCE_PATH, world.data.iatContext)
-  await world.page.goto(new URL(url, config.baseURL).toString())
   await selectGuidanceOptionAndContinueIfPresent(world.page)
 
   if (config.isRealDefraId) {
@@ -70,6 +60,27 @@ export async function navigateAndAuthenticate(world, targetPath, options = {}) {
   if (!options.skipCookies) {
     await acceptCookies(world.page)
   }
+}
+
+export async function navigateAndAuthenticate(world, targetPath, options = {}) {
+  const config = getConfig()
+
+  if (!world.data?.iatContext) {
+    throw new Error(
+      'Test data must include iatContext before navigating. ' +
+        'Call a test data factory (e.g. createValidProjectNameData) first.'
+    )
+  }
+
+  // Register user BEFORE navigating so the authorize page includes their login link
+  if (!config.isRealDefraId && !world.testUser) {
+    world.testUser = await registerTestUser(config.defraIdUrl)
+  }
+
+  const url = buildNavigationUrl(GUIDANCE_PATH, world.data.iatContext)
+  await world.page.goto(new URL(url, config.baseURL).toString())
+
+  await authenticateFromGuidancePage(world, options)
 }
 
 export async function signOut(page) {

--- a/test/support/task-flow.js
+++ b/test/support/task-flow.js
@@ -76,6 +76,15 @@ export async function clickConfirmAndSend(page) {
 
 export async function submitNotification(world) {
   await completeAllTasks(world)
+  await submitCompletedExemption(world)
+}
+
+export async function submitNotificationFromCurrentPage(world) {
+  await completeTasksFromCurrentPage(world)
+  await submitCompletedExemption(world)
+}
+
+export async function submitCompletedExemption(world) {
   await clickReviewAndSend(world.page)
   await clickConfirmAndSend(world.page)
 


### PR DESCRIPTION
- ML-1166: assert the IAT context query string (ACTIVITY_TYPE, subtype, ADV_TYPE, ARTICLE) carried into the exemption journey on Continue, per activity type
- ML-1166/ML-1299 AC1: the answers URL handed off surfaces as the View answers link on check your answers and opens the IAT answers page
- ML-1299 : the View answers link on the View details page opens the IAT answers page with print and save as PDF options
- ML-1299 a Fivium-sourced exemption shows the Download a copy of your answers (PDF) link on CYA and View details
- set FRONTEND_BASE_URL in defaults.env 

covers ML-1166 and ML-1299

