### PR TITLE
ML-1167 update IAT outcome tests for MCMS handoff and add context tests

### DIFF
--- a/test/features/iat/iat.mcms.handoff.feature
+++ b/test/features/iat/iat.mcms.handoff.feature
@@ -1,0 +1,30 @@
+@iat
+Feature: IAT: passing context into the MCMS handoff
+  As an applicant who reaches a marine licence terminal outcome in the IAT
+  I want the handoff button to carry my IAT context into the MCMS service
+  So that my MCMS application is pre-populated from my IAT answers
+
+  @issue=ML-1167
+  Scenario: The handoff button passes the IAT context to the configured MCMS service
+    Given the user walks the IAT to the outcome "/fast-track-mla"
+    When the user follows the MCMS handoff button
+    Then the MCMS handoff URL points at the configured MCMS service
+    And the MCMS handoff URL carries the journey id and the view answers link
+    And the MCMS handoff URL responds with status 200
+
+  @issue=ML-1167
+  Scenario: The handoff URL includes the mapped answers from the IAT journey
+    Given the user walks the IAT to the outcome "/fast-track-mla"
+    When the user follows the MCMS handoff button
+    Then the MCMS handoff URL includes mapped answers for
+      | mapping                  |
+      | ACTIVITY_TYPE            |
+      | ACTIVITY_SUBTYPE_DEPOSIT |
+
+  @issue=ML-1167
+  Scenario: The handoff URL includes the outcome parameters
+    Given the user walks the IAT to the outcome "/fast-track-mla"
+    When the user follows the MCMS handoff button
+    Then the MCMS handoff URL contains the outcome parameters
+      | parameter  | value |
+      | FAST_TRACK | true  |

--- a/test/features/iat/iat.mcms.handoff.feature
+++ b/test/features/iat/iat.mcms.handoff.feature
@@ -11,9 +11,9 @@ Feature: IAT: passing context into the MCMS handoff
     Then the MCMS handoff URL points at the configured MCMS service
     And the MCMS handoff URL carries the journey id and the view answers link
     And the MCMS handoff URL includes mapped answers for
-      | mapping                  |
-      | ACTIVITY_TYPE            |
-      | ACTIVITY_SUBTYPE_DEPOSIT |
+      | mapping                  | answerId |
+      | ACTIVITY_TYPE            | DEPOSIT  |
+      | ACTIVITY_SUBTYPE_DEPOSIT | BAS      |
     And the MCMS handoff URL contains the outcome parameters
       | parameter  | value |
       | FAST_TRACK | true  |

--- a/test/features/iat/iat.mcms.handoff.feature
+++ b/test/features/iat/iat.mcms.handoff.feature
@@ -10,21 +10,11 @@ Feature: IAT: passing context into the MCMS handoff
     When the user follows the MCMS handoff button
     Then the MCMS handoff URL points at the configured MCMS service
     And the MCMS handoff URL carries the journey id and the view answers link
-    And the MCMS handoff URL responds with status 200
-
-  @issue=ML-1167
-  Scenario: The handoff URL includes the mapped answers from the IAT journey
-    Given the user walks the IAT to the outcome "/fast-track-mla"
-    When the user follows the MCMS handoff button
-    Then the MCMS handoff URL includes mapped answers for
+    And the MCMS handoff URL includes mapped answers for
       | mapping                  |
       | ACTIVITY_TYPE            |
       | ACTIVITY_SUBTYPE_DEPOSIT |
-
-  @issue=ML-1167
-  Scenario: The handoff URL includes the outcome parameters
-    Given the user walks the IAT to the outcome "/fast-track-mla"
-    When the user follows the MCMS handoff button
-    Then the MCMS handoff URL contains the outcome parameters
+    And the MCMS handoff URL contains the outcome parameters
       | parameter  | value |
       | FAST_TRACK | true  |
+    And the MCMS handoff URL responds with status 200

--- a/test/features/iat/iat.terminal.outcome.feature
+++ b/test/features/iat/iat.terminal.outcome.feature
@@ -2,16 +2,17 @@
 Feature: IAT: Terminal outcome pages
   As an applicant using the IAT
   I want terminal outcome pages to give me a final result
-  So that I can read the outcome and see a Continue button
+  So that I can read the outcome and continue into the relevant service
 
-  Scenario Outline: Terminal outcome page "<route>" renders heading, body and a Continue button
+  @issue=ML-1167
+  Scenario Outline: Terminal outcome page "<route>" renders heading, body and an MCMS handoff button
     Given the user walks the IAT to the outcome "<route>"
     When the user views the IAT outcome page
     Then the IAT terminal outcome page "<route>" is displayed with heading "<heading>"
     And the page has a body content block
-    And the page has a placeholder Continue button
+    And the page has an MCMS handoff button labelled "<button>"
 
     Examples:
-      | route           | heading                              |
-      | /fast-track-mla | Self-service marine licensing        |
-      | /mod-permission | MOD permission not sought or granted |
+      | route           | heading                              | button                                  |
+      | /fast-track-mla | Self-service marine licensing        | Apply for a self-service marine licence |
+      | /mod-permission | MOD permission not sought or granted | Apply for a standard marine licence     |

--- a/test/features/iat/iat.view.answers.feature
+++ b/test/features/iat/iat.view.answers.feature
@@ -31,11 +31,11 @@ Feature: IAT: Licence not required outcomes and viewing answers
     And the Back link points to the first IAT question
 
   @issue=ML-1165
-  Scenario: The View answers link is shown beneath the Continue button and opens in a new tab
+  Scenario: The View answers link is shown beneath the main action button and opens in a new tab
     Given the user walks the IAT to the outcome "/fast-track-mla"
     When the user views the IAT outcome page
     Then the page has a "View answers" link that opens in a new tab
-    And the "View answers" link is displayed beneath the Continue button
+    And the "View answers" link is displayed beneath the main action button
 
   @issue=ML-1165
   Scenario: The IAT answers page shows the saved answers on a unique, print-friendly page

--- a/test/steps/iat.mcms.handoff.steps.js
+++ b/test/steps/iat.mcms.handoff.steps.js
@@ -14,12 +14,18 @@ When('the user follows the MCMS handoff button', async function () {
   const href = await button.getAttribute('href')
   expect(href, 'handoff button href').toMatch(/\/continue\//)
 
-  // The /continue route 302-redirects to the external MCMS service — capture the
-  // Location header without following it so we can assert the query string the
-  // frontend built. page.request shares the browser context cookies / IAT session.
-  const absolute = new URL(href, this.page.url()).toString()
-  const response = await this.page.request.get(absolute, { maxRedirects: 0 })
-  expect(response.status(), 'continue route should 302 to MCMS').toBe(302)
+  // Follow the handoff through the browser, NOT page.request: page.request uses
+  // Node's DNS and can't resolve the app host that the browser reaches via
+  // Chromium host-resolver-rules (fails in CI as EAI_AGAIN). Capture the 302 to
+  // MCMS from the browser network; the external MCMS target need not load.
+  const continueUrl = new URL(href, this.page.url()).toString()
+  const handoffResponse = this.page.waitForResponse(
+    (response) => response.url().includes('/continue/'),
+    { timeout: 30_000 }
+  )
+  await this.page.goto(continueUrl, { waitUntil: 'commit' }).catch(() => {}) // the 302 target (external MCMS) may be unreachable from CI
+  const response = await handoffResponse
+  expect(response.status(), 'continue route should redirect to MCMS').toBe(302)
 
   this.mcmsHandoffUrl = response.headers().location
   expect(this.mcmsHandoffUrl, 'MCMS handoff Location header').toBeTruthy()
@@ -75,8 +81,6 @@ Then(
 )
 
 Then('the MCMS handoff URL responds with status 200', async function () {
-  // Live contract check: the MCMS service must accept the handoff URL the
-  // frontend built from the IAT context (needs outbound access to MCMS).
   const response = await this.page.request.get(this.mcmsHandoffUrl, {
     timeout: 30_000
   })

--- a/test/steps/iat.mcms.handoff.steps.js
+++ b/test/steps/iat.mcms.handoff.steps.js
@@ -57,11 +57,8 @@ Then(
   'the MCMS handoff URL includes mapped answers for',
   async function (dataTable) {
     const params = new URL(this.mcmsHandoffUrl).searchParams
-    for (const { mapping } of dataTable.hashes()) {
-      expect(
-        params.get(mapping),
-        `mapped answer ${mapping} should be present and non-empty`
-      ).toBeTruthy()
+    for (const { mapping, answerId } of dataTable.hashes()) {
+      expect(params.get(mapping), `mapped answer ${mapping}`).toBe(answerId)
     }
   }
 )

--- a/test/steps/iat.mcms.handoff.steps.js
+++ b/test/steps/iat.mcms.handoff.steps.js
@@ -14,16 +14,12 @@ When('the user follows the MCMS handoff button', async function () {
   const href = await button.getAttribute('href')
   expect(href, 'handoff button href').toMatch(/\/continue\//)
 
-  // Follow the handoff through the browser, NOT page.request: page.request uses
-  // Node's DNS and can't resolve the app host that the browser reaches via
-  // Chromium host-resolver-rules (fails in CI as EAI_AGAIN). Capture the 302 to
-  // MCMS from the browser network; the external MCMS target need not load.
   const continueUrl = new URL(href, this.page.url()).toString()
   const handoffResponse = this.page.waitForResponse(
     (response) => response.url().includes('/continue/'),
     { timeout: 30_000 }
   )
-  await this.page.goto(continueUrl, { waitUntil: 'commit' }).catch(() => {}) // the 302 target (external MCMS) may be unreachable from CI
+  await this.page.goto(continueUrl, { waitUntil: 'commit' }).catch(() => {})
   const response = await handoffResponse
   expect(response.status(), 'continue route should redirect to MCMS').toBe(302)
 

--- a/test/steps/iat.mcms.handoff.steps.js
+++ b/test/steps/iat.mcms.handoff.steps.js
@@ -1,0 +1,84 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+const MCMS_URL =
+  process.env.MCMS_URL || 'https://marinelicensingtest.marinemanagement.org.uk/'
+const MCMS_PATH =
+  process.env.MCMS_PATH || 'mmofox5uat/fox/mmo/MMO_IAT_INTEGRATION'
+
+When('the user follows the MCMS handoff button', async function () {
+  await expect(this.page).toHaveURL(/\/outcome\//, { timeout: 30_000 })
+
+  const button = this.page.locator('main a.govuk-button').first()
+  await expect(button).toBeVisible({ timeout: 30_000 })
+  const href = await button.getAttribute('href')
+  expect(href, 'handoff button href').toMatch(/\/continue\//)
+
+  // The /continue route 302-redirects to the external MCMS service — capture the
+  // Location header without following it so we can assert the query string the
+  // frontend built. page.request shares the browser context cookies / IAT session.
+  const absolute = new URL(href, this.page.url()).toString()
+  const response = await this.page.request.get(absolute, { maxRedirects: 0 })
+  expect(response.status(), 'continue route should 302 to MCMS').toBe(302)
+
+  this.mcmsHandoffUrl = response.headers().location
+  expect(this.mcmsHandoffUrl, 'MCMS handoff Location header').toBeTruthy()
+  if (this.attach) {
+    this.attach(`MCMS handoff URL -> ${this.mcmsHandoffUrl}`, 'text/plain')
+  }
+})
+
+Then(
+  'the MCMS handoff URL points at the configured MCMS service',
+  async function () {
+    const url = new URL(this.mcmsHandoffUrl)
+    const expected = new URL(MCMS_PATH, MCMS_URL)
+    expect(`${url.origin}${url.pathname}`).toBe(
+      `${expected.origin}${expected.pathname}`
+    )
+  }
+)
+
+Then(
+  'the MCMS handoff URL carries the journey id and the view answers link',
+  async function () {
+    const params = new URL(this.mcmsHandoffUrl).searchParams
+    expect(params.get('journeyId'), 'journeyId query param').toBeTruthy()
+    expect(
+      params.get('viewAnswersUrl'),
+      'viewAnswersUrl query param'
+    ).toBeTruthy()
+  }
+)
+
+Then(
+  'the MCMS handoff URL includes mapped answers for',
+  async function (dataTable) {
+    const params = new URL(this.mcmsHandoffUrl).searchParams
+    for (const { mapping } of dataTable.hashes()) {
+      expect(
+        params.get(mapping),
+        `mapped answer ${mapping} should be present and non-empty`
+      ).toBeTruthy()
+    }
+  }
+)
+
+Then(
+  'the MCMS handoff URL contains the outcome parameters',
+  async function (dataTable) {
+    const params = new URL(this.mcmsHandoffUrl).searchParams
+    for (const { parameter, value } of dataTable.hashes()) {
+      expect(params.get(parameter), `outcome param ${parameter}`).toBe(value)
+    }
+  }
+)
+
+Then('the MCMS handoff URL responds with status 200', async function () {
+  // Live contract check: the MCMS service must accept the handoff URL the
+  // frontend built from the IAT context (needs outbound access to MCMS).
+  const response = await this.page.request.get(this.mcmsHandoffUrl, {
+    timeout: 30_000
+  })
+  expect(response.status(), `GET ${this.mcmsHandoffUrl}`).toBe(200)
+})

--- a/test/steps/iat.terminal.outcome.steps.js
+++ b/test/steps/iat.terminal.outcome.steps.js
@@ -34,11 +34,15 @@ Then('the page has a body content block', async function () {
   expect(text.length).toBeGreaterThan(0)
 })
 
-Then('the page has a placeholder Continue button', async function () {
-  // The Continue button on terminal outcome pages is a placeholder pending
-  // ML-1166 (passing IAT context into exemption journey) and ML-1167 (passing
-  // context into MCMS journeys). It renders as an anchor with href="#".
-  const button = this.page.locator('main a.govuk-button:has-text("Continue")')
-  await expect(button.first()).toBeVisible({ timeout: 30_000 })
-  await expect(button.first()).toHaveAttribute('href', '#', { timeout: 30_000 })
-})
+Then(
+  'the page has an MCMS handoff button labelled {string}',
+  async function (label) {
+    // ML-1167: an outcome that hands off to MCMS labels its main button with
+    // the outcome heading (not "Continue") and points it at the internal
+    // /continue/{id}/{route} route, which 302-redirects to the MCMS service.
+    const button = this.page.locator(`main a.govuk-button:has-text("${label}")`)
+    await expect(button.first()).toBeVisible({ timeout: 30_000 })
+    const href = await button.first().getAttribute('href')
+    expect(href).toMatch(/\/continue\//)
+  }
+)

--- a/test/steps/iat.terminal.outcome.steps.js
+++ b/test/steps/iat.terminal.outcome.steps.js
@@ -37,9 +37,6 @@ Then('the page has a body content block', async function () {
 Then(
   'the page has an MCMS handoff button labelled {string}',
   async function (label) {
-    // ML-1167: an outcome that hands off to MCMS labels its main button with
-    // the outcome heading (not "Continue") and points it at the internal
-    // /continue/{id}/{route} route, which 302-redirects to the MCMS service.
     const button = this.page.locator(`main a.govuk-button:has-text("${label}")`)
     await expect(button.first()).toBeVisible({ timeout: 30_000 })
     const href = await button.first().getAttribute('href')

--- a/test/steps/iat.view.answers.steps.js
+++ b/test/steps/iat.view.answers.steps.js
@@ -6,23 +6,25 @@ const FIRST_QUESTION_REGEX = /\/journey\/self-service\/c\/[^/]+\/sea$/
 const ANSWER_URL_PATTERN = /\/journey\/self-service\/outcome-document\/[\w-]+$/
 
 Then(
-  'the "View answers" link is displayed beneath the Continue button',
+  'the "View answers" link is displayed beneath the main action button',
   async function () {
     const beneath = await this.page.evaluate(() => {
       const main = document.querySelector('main')
-      const cont = [...main.querySelectorAll('a.govuk-button, button')].find(
-        (e) => /continue/i.test(e.textContent)
-      )
+      // ML-1167: the main CTA is the handoff button (labelled with the outcome
+      // heading), no longer literally "Continue" — match the primary button.
+      const cta =
+        main.querySelector('.app-iat-actions a.govuk-button') ||
+        main.querySelector('a.govuk-button')
       const va = [...main.querySelectorAll('a')].find((a) =>
         /view answers/i.test(a.textContent)
       )
-      if (!cont || !va) return false
+      if (!cta || !va) return false
 
-      return !!(cont.compareDocumentPosition(va) & 4)
+      return !!(cta.compareDocumentPosition(va) & 4)
     })
     expect(
       beneath,
-      'View answers link should appear after the Continue button'
+      'View answers link should appear after the main action button'
     ).toBe(true)
   }
 )


### PR DESCRIPTION
Test updates for the failing IAT test and test coverage to MCMS handoff 



## Dependencies

Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/759


