### PR TITLE
ML-1167 fix MCMS handoff 

### DIFF
--- a/test/steps/iat.mcms.handoff.steps.js
+++ b/test/steps/iat.mcms.handoff.steps.js
@@ -74,8 +74,10 @@ Then(
 )
 
 Then('the MCMS handoff URL responds with status 200', async function () {
-  const response = await this.page.request.get(this.mcmsHandoffUrl, {
+  const response = await this.page.goto(this.mcmsHandoffUrl, {
+    waitUntil: 'commit',
     timeout: 30_000
   })
+  expect(response, 'MCMS handoff navigation response').toBeTruthy()
   expect(response.status(), `GET ${this.mcmsHandoffUrl}`).toBe(200)
 })


### PR DESCRIPTION
The responds-with-status-200 step used page.request.get updating it to  Use page.goto so the request goes through the browser


