### PR TITLE
Add marine-licensing-api-stub to journey test stack

### DIFF
--- a/compose.common.yml
+++ b/compose.common.yml
@@ -161,6 +161,22 @@ services:
     networks:
       - cdp-tenant
 
+  marine-licensing-api-stub:
+    image: defradigital/marine-licensing-api-stub:${MARINE_LICENSING_API_STUB_VERSION:-latest}
+    restart: unless-stopped
+    environment:
+      PORT: 3002
+      NODE_ENV: development
+    ports:
+      - '3002:3002'
+    networks:
+      - cdp-tenant
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3002/health']
+      interval: 10s
+      start_period: 30s
+      retries: 5
+
   marine-licensing-backend:
     image: defradigital/marine-licensing-backend:${MARINE_LICENSING_BACKEND_VERSION:-latest}
     restart: unless-stopped
@@ -170,7 +186,10 @@ services:
       - PORT=3001
       - MONGODB_URI=mongodb://mongodb:27017/marine-licensing
       - DEFRA_ID_JWKS_URI=http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/jwks.json
+      - ARCGIS_FEATURE_SERVER_URL=http://marine-licensing-api-stub:3002/ArcGIS/rest/services/PolicyData_MDP/FeatureServer/0
     depends_on:
+      marine-licensing-api-stub:
+        condition: service_healthy
       mongodb:
         condition: service_healthy
       redis:

--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -4,6 +4,9 @@ inputs:
   marine-licensing-backend:
     required: false
     type: string
+  marine-licensing-api-stub:
+    required: false
+    type: string
   marine-licensing-frontend:
     required: false
     type: string
@@ -175,6 +178,24 @@ runs:
       shell: bash
       working-directory: ./marine-licensing-journey-tests
 
+    - name: Build marine-licensing-api-stub image
+      run: |
+        echo "=== Building API Stub Image ==="
+        echo "Current directory: $(pwd)"
+
+        if [ -d "../../marine-licensing-api-stub" ]; then
+          echo "✅ Found api-stub directory - building PR image"
+          cd ../../marine-licensing-api-stub
+          echo "Branch: $(git branch --show-current) | Commit: $(git log -1 --oneline)"
+          docker build -t defradigital/marine-licensing-api-stub:pr-build .
+          echo "✅ API stub PR image built successfully"
+        else
+          echo "ℹ️  No api-stub directory found - will use latest image"
+          echo "This is normal if no api-stub dependency was specified in PR description"
+        fi
+      shell: bash
+      working-directory: ./marine-licensing-journey-tests
+
     - uses: actions/setup-node@v4
       with:
         node-version: 22
@@ -210,12 +231,22 @@ runs:
           echo "ℹ️  Using backend version: ${BACKEND_VERSION:-latest} (no PR dependency)"
         fi
 
+        if docker image inspect defradigital/marine-licensing-api-stub:pr-build >/dev/null 2>&1; then
+          echo "✅ Using PR-built api-stub image (from depends-on)"
+          API_STUB_VERSION="pr-build"
+        else
+          API_STUB_VERSION="${{ inputs.marine-licensing-api-stub }}"
+          echo "ℹ️  Using api-stub version: ${API_STUB_VERSION:-latest} (no PR dependency)"
+        fi
+
         echo "🐳 Starting containers with:"
         echo "  Frontend: ${FRONTEND_VERSION:-latest}"
         echo "  Backend: ${BACKEND_VERSION:-latest}"
+        echo "  API stub: ${API_STUB_VERSION:-latest}"
 
         MARINE_LICENSING_FRONTEND_VERSION=${FRONTEND_VERSION:-latest} \
         MARINE_LICENSING_BACKEND_VERSION=${BACKEND_VERSION:-latest} \
+        MARINE_LICENSING_API_STUB_VERSION=${API_STUB_VERSION:-latest} \
         docker compose -f $(pwd)/compose.common.yml up --wait-timeout 300 -d --quiet-pull
 
     - name: Check initial service status


### PR DESCRIPTION
Wire the ArcGIS API stub into compose.common.yml and support PR-based image builds via depends-on, so backend marine plan policy calls use the stub instead of the live ArcGIS service.



