### PR TITLE
update GitHub Pages actions and artifact handling

### DIFF
--- a/.github/workflows/run-tests-and-publish.yml
+++ b/.github/workflows/run-tests-and-publish.yml
@@ -57,13 +57,16 @@ jobs:
           path: ./allure-report
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
+          name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./allure-report
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+        with:
+          artifact_name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
Updated the Pages deployment workflow to use the latest action majors (configure-pages@v6, upload-pages-artifact@v5, deploy-pages@v5) and set a unique Pages artifact name per run attempt to prevent duplicate github-pages artifact deployment failures.
