### PR TITLE
ML-1376 LCML journey tests for the Harbour authority task

### DIFF
--- a/test/features/lcml/lcml.harbour.authority.feature
+++ b/test/features/lcml/lcml.harbour.authority.feature
@@ -4,9 +4,6 @@ Feature: LCML: Harbour authority task
   I want to record whether my project is located in a harbour authority area
   So that the MMO understands the context of my application
 
-  # AC8 (Cancel / Back returns to the task list without changing the saved answer
-  # or status) is intentionally not automated: project convention is not to write
-  # Back-link or Continue-button navigation tests.
 
   Scenario: Harbour authority task is displayed in the Other permissions section with "Not yet started"
     Given an organisation user has started a marine licence application
@@ -29,11 +26,6 @@ Feature: LCML: Harbour authority task
     Given an organisation user has started a marine licence application
     When the user saves "Yes" on the harbour authority page without details
     Then the harbour authority error "Enter details of the harbour authority" is shown
-
-  Scenario: Saving "Yes" with more than 1000 characters shows a validation error
-    Given an organisation user has started a marine licence application
-    When the user saves "Yes" on the harbour authority page with 1001 characters of details
-    Then the harbour authority error "Details of the harbour authority must be 1000 characters or fewer" is shown
 
   Scenario Outline: Saving a valid harbour authority answer marks the task Completed
     Given an organisation user has started a marine licence application

--- a/test/features/lcml/lcml.harbour.authority.feature
+++ b/test/features/lcml/lcml.harbour.authority.feature
@@ -17,15 +17,15 @@ Feature: LCML: Harbour authority task
     And selecting "Yes" reveals the harbour authority details textbox
     And selecting "No" hides the harbour authority details textbox
 
-  Scenario: Saving with no answer selected shows a validation error
+  Scenario Outline: Saving an invalid harbour authority answer shows a validation error
     Given an organisation user has started a marine licence application
-    When the user saves the harbour authority page without selecting an answer
-    Then the harbour authority error "Select whether your project is located in a harbour authority area" is shown
+    When the user saves "<answer>" with details "<details>" on the harbour authority page
+    Then the harbour authority error "<error>" is shown
 
-  Scenario: Saving "Yes" without details shows a validation error
-    Given an organisation user has started a marine licence application
-    When the user saves "Yes" on the harbour authority page without details
-    Then the harbour authority error "Enter details of the harbour authority" is shown
+    Examples:
+      | answer | details | error                                                              |
+      |        |         | Select whether your project is located in a harbour authority area |
+      | Yes    |         | Enter details of the harbour authority                             |
 
   Scenario Outline: Saving a valid harbour authority answer marks the task Completed
     Given an organisation user has started a marine licence application

--- a/test/features/lcml/lcml.harbour.authority.feature
+++ b/test/features/lcml/lcml.harbour.authority.feature
@@ -19,13 +19,13 @@ Feature: LCML: Harbour authority task
 
   Scenario Outline: Saving an invalid harbour authority answer shows a validation error
     Given an organisation user has started a marine licence application
-    When the user saves "<answer>" with details "<details>" on the harbour authority page
+    When the user saves "<answer>" on the harbour authority page
     Then the harbour authority error "<error>" is shown
 
     Examples:
-      | answer | details | error                                                              |
-      |        |         | Select whether your project is located in a harbour authority area |
-      | Yes    |         | Enter details of the harbour authority                             |
+      | answer | error                                                              |
+      |        | Select whether your project is located in a harbour authority area |
+      | Yes    | Enter details of the harbour authority                             |
 
   Scenario Outline: Saving a valid harbour authority answer marks the task Completed
     Given an organisation user has started a marine licence application

--- a/test/features/lcml/lcml.harbour.authority.feature
+++ b/test/features/lcml/lcml.harbour.authority.feature
@@ -1,0 +1,67 @@
+@lcml @issue=ML-1376
+Feature: LCML: Harbour authority task
+  As an applicant
+  I want to record whether my project is located in a harbour authority area
+  So that the MMO understands the context of my application
+
+  # AC8 (Cancel / Back returns to the task list without changing the saved answer
+  # or status) is intentionally not automated: project convention is not to write
+  # Back-link or Continue-button navigation tests.
+
+  Scenario: Harbour authority task is displayed in the Other permissions section with "Not yet started"
+    Given an organisation user has started a marine licence application
+    When the user views the marine licence task list
+    Then the harbour authority task is shown in the Other permissions section with status "Not yet started"
+
+  Scenario: Harbour authority page loads empty with a toggleable details textbox
+    Given an organisation user has started a marine licence application
+    When the user opens the harbour authority task
+    Then the harbour authority page is empty with the details textbox hidden
+    And selecting "Yes" reveals the harbour authority details textbox
+    And selecting "No" hides the harbour authority details textbox
+
+  Scenario: Saving with no answer selected shows a validation error
+    Given an organisation user has started a marine licence application
+    When the user saves the harbour authority page without selecting an answer
+    Then the harbour authority error "Select whether your project is located in a harbour authority area" is shown
+
+  Scenario: Saving "Yes" without details shows a validation error
+    Given an organisation user has started a marine licence application
+    When the user saves "Yes" on the harbour authority page without details
+    Then the harbour authority error "Enter details of the harbour authority" is shown
+
+  Scenario: Saving "Yes" with more than 1000 characters shows a validation error
+    Given an organisation user has started a marine licence application
+    When the user saves "Yes" on the harbour authority page with 1001 characters of details
+    Then the harbour authority error "Details of the harbour authority must be 1000 characters or fewer" is shown
+
+  Scenario Outline: Saving a valid harbour authority answer marks the task Completed
+    Given an organisation user has started a marine licence application
+    When the user saves "<answer>" with details "<details>" on the harbour authority page
+    Then the "Harbour authority" task status is "Completed"
+
+    Examples:
+      | answer | details                                     |
+      | Yes    | Located within the Port of Dover authority  |
+      | No     |                                             |
+
+  Scenario: Harbour authority answer "No" is shown on the Check your answers page
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    When the user opens the check your answers page from the task list
+    Then the harbour authority answer on the check your answers page is "No"
+
+  Scenario: Changing the harbour authority answer via Check your answers bounces back showing the new value
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    When the user opens the check your answers page from the task list
+    And the user changes the harbour authority answer to "Yes" with details "Located within the Port of Dover authority" via check your answers
+    Then the harbour authority answer on the check your answers page is "Located within the Port of Dover authority"
+
+  Scenario: Harbour authority answer is shown read-only on the View details page
+    Given an organisation user has completed all tasks with special legal powers "No", other authorities "No" and sharing consent "Yes"
+    And the activity has type of activity, activity description, maximum duration, completion date, specific months and proposed working hours saved
+    And the user has saved "Yes" with details "Located within the Port of Dover authority" on the harbour authority page
+    When the user submits the marine licence application from the task list
+    And the user views the submitted application on the projects page
+    Then the harbour authority answer on the view details page is "Located within the Port of Dover authority" and read-only

--- a/test/steps/lcml.harbour.authority.steps.js
+++ b/test/steps/lcml.harbour.authority.steps.js
@@ -56,22 +56,6 @@ When('the user opens the harbour authority task', async function () {
 })
 
 When(
-  'the user saves the harbour authority page without selecting an answer',
-  async function () {
-    await openHarbourFromTaskList(this.page)
-    await saveHarbour(this.page)
-  }
-)
-
-When(
-  'the user saves {string} on the harbour authority page without details',
-  async function (answer) {
-    await openHarbourFromTaskList(this.page)
-    await saveHarbour(this.page, { answer })
-  }
-)
-
-When(
   'the user saves {string} with details {string} on the harbour authority page',
   async function (answer, details) {
     await openHarbourFromTaskList(this.page)

--- a/test/steps/lcml.harbour.authority.steps.js
+++ b/test/steps/lcml.harbour.authority.steps.js
@@ -1,0 +1,201 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+const TASK_LINK = 'Harbour authority'
+const PAGE_PATH = '/marine-licence/harbour-authority'
+const TASK_SECTION_ID_PREFIX = 'other-permissions-task-list'
+const HEADING = 'Is your project located in a harbour authority area?'
+const ROW_LABEL = 'Located in a harbour authority area'
+
+function harbourPage(page) {
+  return {
+    yes: page.getByRole('radio', { name: 'Yes' }),
+    no: page.getByRole('radio', { name: 'No' }),
+    details: page.locator('#details'),
+    saveButton: page.locator('button:has-text("Save and continue")')
+  }
+}
+
+function harbourRow(page) {
+  return page.locator(
+    `xpath=//div[contains(@class,"govuk-summary-list__row") and .//dt[normalize-space(text())="${ROW_LABEL}"]]`
+  )
+}
+
+function taskStatusLocator(page) {
+  return page.locator(
+    `xpath=//a[normalize-space(text())="${TASK_LINK}"]/ancestor::li//div[contains(@class,"govuk-task-list__status")]`
+  )
+}
+
+async function openHarbourFromTaskList(page) {
+  await page.getByRole('link', { name: TASK_LINK }).click()
+  await page.waitForLoadState('load')
+}
+
+async function selectAnswer(page, answer) {
+  const h = harbourPage(page)
+  if (answer === 'Yes') {
+    await h.yes.click()
+  } else if (answer === 'No') {
+    await h.no.click()
+  }
+}
+
+async function saveHarbour(page, { answer, details } = {}) {
+  await selectAnswer(page, answer)
+  if (answer === 'Yes' && details) {
+    await harbourPage(page).details.fill(details)
+  }
+  await harbourPage(page).saveButton.click()
+  await page.waitForLoadState('load')
+}
+
+When('the user opens the harbour authority task', async function () {
+  await openHarbourFromTaskList(this.page)
+})
+
+When(
+  'the user saves the harbour authority page without selecting an answer',
+  async function () {
+    await openHarbourFromTaskList(this.page)
+    await saveHarbour(this.page)
+  }
+)
+
+When(
+  'the user saves {string} on the harbour authority page without details',
+  async function (answer) {
+    await openHarbourFromTaskList(this.page)
+    await saveHarbour(this.page, { answer })
+  }
+)
+
+When(
+  'the user saves {string} on the harbour authority page with {int} characters of details',
+  async function (answer, count) {
+    await openHarbourFromTaskList(this.page)
+    await selectAnswer(this.page, answer)
+    // The textarea has a maxlength of 1000, so a normal fill() is truncated to
+    // 1000 and never trips server validation. Set the value programmatically so
+    // the over-length payload is actually submitted.
+    await harbourPage(this.page).details.evaluate((el, value) => {
+      el.value = value
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    }, 'a'.repeat(count))
+    await harbourPage(this.page).saveButton.click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user saves {string} with details {string} on the harbour authority page',
+  async function (answer, details) {
+    await openHarbourFromTaskList(this.page)
+    await saveHarbour(this.page, { answer, details })
+  }
+)
+
+Given(
+  'the user has saved {string} with details {string} on the harbour authority page',
+  async function (answer, details) {
+    await openHarbourFromTaskList(this.page)
+    await saveHarbour(this.page, { answer, details })
+    await expect(taskStatusLocator(this.page)).toContainText('Completed', {
+      timeout: 30_000
+    })
+  }
+)
+
+When(
+  'the user changes the harbour authority answer to {string} with details {string} via check your answers',
+  async function (answer, details) {
+    await harbourRow(this.page).locator('a:has-text("Change")').click()
+    await this.page.waitForLoadState('load')
+    await selectAnswer(this.page, answer)
+    if (answer === 'Yes' && details) {
+      await harbourPage(this.page).details.fill(details)
+    }
+    await harbourPage(this.page).saveButton.click()
+    await this.page.waitForLoadState('load')
+    await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the harbour authority task is shown in the Other permissions section with status {string}',
+  async function (status) {
+    const link = this.page.getByRole('link', { name: TASK_LINK })
+    await expect(link).toBeVisible({ timeout: 30_000 })
+    // The status <div> carries id="other-permissions-task-list-{n}-status",
+    // which confirms the task sits within the Other permissions section.
+    const statusEl = taskStatusLocator(this.page)
+    await expect(statusEl).toHaveAttribute(
+      'id',
+      new RegExp(`^${TASK_SECTION_ID_PREFIX}-`)
+    )
+    await expect(statusEl).toContainText(status, { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the harbour authority page is empty with the details textbox hidden',
+  async function () {
+    await expect(this.page).toHaveURL(new RegExp(PAGE_PATH), {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('h1')).toContainText(HEADING, {
+      timeout: 30_000
+    })
+    const h = harbourPage(this.page)
+    expect(await h.yes.isChecked()).toBe(false)
+    expect(await h.no.isChecked()).toBe(false)
+    await expect(h.details).toBeHidden()
+  }
+)
+
+Then(
+  /^selecting "(Yes|No)" (reveals|hides) the harbour authority details textbox$/,
+  async function (answer, action) {
+    await selectAnswer(this.page, answer)
+    const details = harbourPage(this.page).details
+    if (action === 'reveals') {
+      await expect(details).toBeVisible({ timeout: 30_000 })
+    } else {
+      await expect(details).toBeHidden({ timeout: 30_000 })
+    }
+  }
+)
+
+Then('the harbour authority error {string} is shown', async function (message) {
+  await expect(this.page.locator('.govuk-error-summary')).toContainText(
+    message,
+    { timeout: 30_000 }
+  )
+  await expect(this.page).toHaveURL(new RegExp(PAGE_PATH), {
+    timeout: 30_000
+  })
+})
+
+Then(
+  'the harbour authority answer on the check your answers page is {string}',
+  async function (expected) {
+    await expect(harbourRow(this.page).locator('dd').first()).toContainText(
+      expected,
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then(
+  'the harbour authority answer on the view details page is {string} and read-only',
+  async function (expected) {
+    const row = harbourRow(this.page)
+    await expect(row.locator('dd').first()).toContainText(expected, {
+      timeout: 30_000
+    })
+    await expect(row.locator('a:has-text("Change")')).toHaveCount(0)
+  }
+)

--- a/test/steps/lcml.harbour.authority.steps.js
+++ b/test/steps/lcml.harbour.authority.steps.js
@@ -56,6 +56,14 @@ When('the user opens the harbour authority task', async function () {
 })
 
 When(
+  'the user saves {string} on the harbour authority page',
+  async function (answer) {
+    await openHarbourFromTaskList(this.page)
+    await saveHarbour(this.page, { answer })
+  }
+)
+
+When(
   'the user saves {string} with details {string} on the harbour authority page',
   async function (answer, details) {
     await openHarbourFromTaskList(this.page)

--- a/test/steps/lcml.harbour.authority.steps.js
+++ b/test/steps/lcml.harbour.authority.steps.js
@@ -72,23 +72,6 @@ When(
 )
 
 When(
-  'the user saves {string} on the harbour authority page with {int} characters of details',
-  async function (answer, count) {
-    await openHarbourFromTaskList(this.page)
-    await selectAnswer(this.page, answer)
-    // The textarea has a maxlength of 1000, so a normal fill() is truncated to
-    // 1000 and never trips server validation. Set the value programmatically so
-    // the over-length payload is actually submitted.
-    await harbourPage(this.page).details.evaluate((el, value) => {
-      el.value = value
-      el.dispatchEvent(new Event('input', { bubbles: true }))
-    }, 'a'.repeat(count))
-    await harbourPage(this.page).saveButton.click()
-    await this.page.waitForLoadState('load')
-  }
-)
-
-When(
   'the user saves {string} with details {string} on the harbour authority page',
   async function (answer, details) {
     await openHarbourFromTaskList(this.page)

--- a/test/steps/lcml.pre.application.consultation.steps.js
+++ b/test/steps/lcml.pre.application.consultation.steps.js
@@ -3,7 +3,6 @@ import { expect } from '@playwright/test'
 import { loginAndStartApplication } from '../support/lcml-helpers.js'
 
 const TASK_LINK = 'Pre-application consultation'
-const STATUS_ID = '#other-permissions-task-list-3-status'
 const PAGE_PATH = '/marine-licence/public-consultation'
 const TASK_LIST_PATH = '/marine-licence/task-list'
 const CONSULTATION_ROW_LABEL =
@@ -12,6 +11,12 @@ const CONSULTATION_ROW_LABEL =
 function consultationRow(page) {
   return page.locator(
     `xpath=//div[contains(@class,"govuk-summary-list__row") and .//dt[normalize-space(text())="${CONSULTATION_ROW_LABEL}"]]`
+  )
+}
+
+function consultationStatus(page) {
+  return page.locator(
+    `xpath=//a[normalize-space(text())="${TASK_LINK}"]/ancestor::li//div[contains(@class,"govuk-task-list__status")]`
   )
 }
 
@@ -59,7 +64,7 @@ Given(
   'the user has saved {string} with details {string} on pre-application consultation',
   async function (answer, details) {
     await saveConsultation(this.page, answer, details)
-    await expect(this.page.locator(STATUS_ID)).toContainText('Completed', {
+    await expect(consultationStatus(this.page)).toContainText('Completed', {
       timeout: 30_000
     })
   }


### PR DESCRIPTION
## What

Adds LCML journey tests for the **Harbour authority** task (ML-1376), stacked on #315 (the harbour authority helper wiring).

## Scenarios (`test/features/lcml/lcml.harbour.authority.feature`, `@lcml @issue=ML-1376`)

| AC | Scenario | Notes |
|----|----------|-------|
| AC1 | Task shown in "Other permissions" with "Not yet started" | section membership asserted via status-div id |
| AC2/AC3 | Page loads empty; Yes reveals / No hides the details textbox | |
| AC4/AC5 | Invalid answer shows validation error | scenario outline (no answer / Yes-without-details) |
| AC7 | Valid answer marks task "Completed" | scenario outline (Yes / No) |
| AC9 | Answer shown on Check your answers + change bounces back | "No"→"No"; "Yes"→details text (not the word "Yes") |
| AC10 | Answer shown read-only on View details | |

## Deliberately excluded

- **AC6 (>1000 chars)** — removed at request.
- **AC8 (Cancel / Back navigation)** — not automated per the project's no-navigation-test convention.

## Also fixed

The Harbour authority task shifting the "Other permissions" section moved the pre-application consultation task from positional index 3 → 4, breaking `#other-permissions-task-list-3-status`. Switched that check to a name-based (order-independent) locator.

## Verification

All harbour scenarios pass against the local Docker stack; gherkin/eslint/steps linters clean.

Note on AC4 wording: the AC text says "...located **within** a harbour authority area" but the app's actual error copy is "...located **in**...". The test asserts the real app string — worth confirming which copy is correct.