### PR TITLE
ML-1287: journey tests for re-querying marine plan policies after site changes

### DIFF
--- a/test/features/lcml/lcml.marine.plan.policies.feature
+++ b/test/features/lcml/lcml.marine.plan.policies.feature
@@ -85,23 +85,46 @@ Feature: LCML: Marine plan policies
       | policy list          |
       | policy consideration |
 
-  @issue=ML-1287
-  Scenario: Changing the width of a circular site re-queries the marine plan policies
+  @issue=ML-1261
+  Scenario: The finished-site-details question is shown once all site details are complete
     Given an organisation user has completed the site details for a marine licence application
-    And the user opens the review site details page from the task list
-    When the user changes the width of the circular site and continues
-    Then the marine plan policies are re-queried
+    When the user opens the review site details page from the task list
+    Then the review page shows the marine plan policies heading and the finished-site-details question
+    And neither finished-site-details radio is selected
 
-  @issue=ML-1287
-  Scenario: Adding another site re-queries the marine plan policies
-    Given an organisation user has completed the site details for a marine licence application
-    And the user opens the review site details page from the task list
-    When the user adds another circular site and continues
-    Then the marine plan policies are re-queried
+  @issue=ML-1261
+  Scenario: The finished-site-details question is hidden while site details are incomplete
+    Given an organisation user has manually entered a circular site for a marine licence
+    When the user views the review site details page
+    Then the review page does not show the finished-site-details question
 
-  @issue=ML-1287
-  Scenario: Renaming a site does not re-query the marine plan policies
+  @issue=ML-1261
+  Scenario: Selecting Continue without answering the finished-site-details question shows an error
     Given an organisation user has completed the site details for a marine licence application
     And the user opens the review site details page from the task list
-    When the user changes the site name and continues
-    Then the marine plan policies are not re-queried
+    When the user selects Continue without answering the finished-site-details question
+    Then the finished-site-details error "Select if you have finished entering your site details" is shown
+
+  @issue=ML-1287 @issue=ML-1261
+  Scenario: Answering Yes after changing the width re-queries the marine plan policies
+    Given an organisation user has completed the site details for a marine licence application
+    And the user opens the review site details page from the task list
+    When the user changes the width of the circular site
+    And the user answers "Yes" and continues from the review page
+    Then the "Marine plan policy considerations" task is "Not yet started" and shows the number of policies to complete
+
+  @issue=ML-1287 @issue=ML-1261
+  Scenario: Answering Yes after adding another site re-queries the marine plan policies
+    Given an organisation user has completed the site details for a marine licence application
+    And the user opens the review site details page from the task list
+    When the user adds another circular site
+    And the user answers "Yes" and continues from the review page
+    Then the "Marine plan policy considerations" task is "Not yet started" and shows the number of policies to complete
+
+  @issue=ML-1261
+  Scenario: Answering No returns to the task list without re-querying and resets the tasks
+    Given an organisation user has completed the site details for a marine licence application
+    And the user opens the review site details page from the task list
+    When the user answers "No" and continues from the review page
+    Then the "Marine plan policy considerations" task is "Cannot start yet" and is not a link
+    And the "Site details" task has status "In progress"

--- a/test/features/lcml/lcml.marine.plan.policies.feature
+++ b/test/features/lcml/lcml.marine.plan.policies.feature
@@ -84,3 +84,24 @@ Feature: LCML: Marine plan policies
       | task list            |
       | policy list          |
       | policy consideration |
+
+  @issue=ML-1287
+  Scenario: Changing the width of a circular site re-queries the marine plan policies
+    Given an organisation user has completed the site details for a marine licence application
+    And the user opens the review site details page from the task list
+    When the user changes the width of the circular site and continues
+    Then the marine plan policies are re-queried
+
+  @issue=ML-1287
+  Scenario: Adding another site re-queries the marine plan policies
+    Given an organisation user has completed the site details for a marine licence application
+    And the user opens the review site details page from the task list
+    When the user adds another circular site and continues
+    Then the marine plan policies are re-queried
+
+  @issue=ML-1287
+  Scenario: Renaming a site does not re-query the marine plan policies
+    Given an organisation user has completed the site details for a marine licence application
+    And the user opens the review site details page from the task list
+    When the user changes the site name and continues
+    Then the marine plan policies are not re-queried

--- a/test/steps/lcml.marine.plan.policies.steps.js
+++ b/test/steps/lcml.marine.plan.policies.steps.js
@@ -9,7 +9,7 @@ import {
   enterCircleSiteDetails,
   completeActivityDetailsFromReview,
   openReviewSiteDetailsFromTaskList,
-  continueFromReviewObservingRequery
+  finishSiteDetailsAndContinue
 } from '../support/lcml-helpers.js'
 import {
   clickAddTypeOfActivity,
@@ -411,19 +411,15 @@ Given(
   }
 )
 
-When(
-  'the user changes the width of the circular site and continues',
-  async function () {
-    const review = new ReviewSiteDetailsPage(this.page)
-    await review.widthChangeLink().click()
-    await this.page.waitForLoadState('load')
-    await enterWidth(this.page, Number(this.data.site.width) + 25)
-    await this.page.waitForLoadState('load')
-    await continueFromReviewObservingRequery(this)
-  }
-)
+When('the user changes the width of the circular site', async function () {
+  const review = new ReviewSiteDetailsPage(this.page)
+  await review.widthChangeLink().click()
+  await this.page.waitForLoadState('load')
+  await enterWidth(this.page, Number(this.data.site.width) + 25)
+  await this.page.waitForLoadState('load')
+})
 
-When('the user adds another circular site and continues', async function () {
+When('the user adds another circular site', async function () {
   await this.page
     .locator('button[name="add"]:has-text("Add another site")')
     .click()
@@ -435,25 +431,80 @@ When('the user adds another circular site and continues', async function () {
     width: '30'
   })
   await completeActivityForSite(this, 2)
-  await continueFromReviewObservingRequery(this)
 })
 
-When('the user changes the site name and continues', async function () {
-  const review = new ReviewSiteDetailsPage(this.page)
-  await review.siteNameChangeLink(1).click()
-  await this.page.waitForLoadState('load')
-  await this.page
-    .locator('#siteName')
-    .fill(`Renamed Site ${faker.location.city()}`)
-  await this.page.locator('button:has-text("Save and continue")').click()
-  await this.page.waitForLoadState('load')
-  await continueFromReviewObservingRequery(this)
+When(
+  'the user answers {string} and continues from the review page',
+  async function (answer) {
+    await finishSiteDetailsAndContinue(this.page, answer.toLowerCase())
+  }
+)
+
+// --- ML-1261: "Have you finished entering your site details?" question ---
+
+Then(
+  'the review page shows the marine plan policies heading and the finished-site-details question',
+  async function () {
+    await expect(
+      this.page.locator('h2', { hasText: 'Marine plan policies' }).first()
+    ).toBeVisible({ timeout: 30_000 })
+    await expect(
+      this.page.getByText('Have you finished entering your site details?')
+    ).toBeVisible({ timeout: 30_000 })
+  }
+)
+
+Then('neither finished-site-details radio is selected', async function () {
+  await expect(
+    this.page.locator('#finishedEnteringSiteDetails')
+  ).not.toBeChecked()
+  await expect(
+    this.page.locator('#finishedEnteringSiteDetails-2')
+  ).not.toBeChecked()
 })
 
-Then('the marine plan policies are re-queried', async function () {
-  expect(this.data.requeried).toBe(true)
-})
+Then(
+  'the review page does not show the finished-site-details question',
+  async function () {
+    await expect(this.page.locator('#finishedEnteringSiteDetails')).toHaveCount(
+      0
+    )
+    await expect(
+      this.page.getByText('Have you finished entering your site details?')
+    ).toHaveCount(0)
+  }
+)
 
-Then('the marine plan policies are not re-queried', async function () {
-  expect(this.data.requeried).toBe(false)
-})
+When(
+  'the user selects Continue without answering the finished-site-details question',
+  async function () {
+    await this.page.locator('button:has-text("Continue")').click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then(
+  'the finished-site-details error {string} is shown',
+  async function (message) {
+    await expect(this.page.locator('.govuk-error-summary')).toContainText(
+      message,
+      { timeout: 30_000 }
+    )
+    await expect(this.page).toHaveURL(/review-site-details/, {
+      timeout: 30_000
+    })
+  }
+)
+
+Then(
+  'the {string} task has status {string}',
+  async function (taskName, status) {
+    const task = this.page
+      .locator('li.govuk-task-list__item', { hasText: taskName })
+      .first()
+    await expect(task.locator('.govuk-task-list__status')).toContainText(
+      status,
+      { timeout: 30_000 }
+    )
+  }
+)

--- a/test/steps/lcml.marine.plan.policies.steps.js
+++ b/test/steps/lcml.marine.plan.policies.steps.js
@@ -1,9 +1,23 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import ReviewSiteDetailsPage from '../pages/review.site.details.page.js'
+import { enterWidth } from '../support/site-details-flow.js'
 import {
   completeManualCircleApp,
-  openMarinePlanPolicyList
+  openMarinePlanPolicyList,
+  enterCircleSiteDetails,
+  completeActivityDetailsFromReview,
+  openReviewSiteDetailsFromTaskList,
+  continueFromReviewObservingRequery
 } from '../support/lcml-helpers.js'
+import {
+  clickAddTypeOfActivity,
+  selectActivityTypeAndContinue,
+  pickRandomNonOtherCheckbox,
+  checkCheckboxById,
+  submitWhatActivityForm
+} from '../support/lcml-activity-flow.js'
 
 const POLICY_MAP_URL =
   'https://environment.data.gov.uk/marine-plans-explorer/policy'
@@ -375,3 +389,71 @@ Then(
     ).toHaveCount(0)
   }
 )
+
+async function completeActivityForSite(world, siteNumber) {
+  const { pickRandomActivity } = await import('../test-data/lcml-activity.js')
+  await clickAddTypeOfActivity(world.page, siteNumber, 1)
+  const { topLevel, subOption } = pickRandomActivity()
+  await selectActivityTypeAndContinue(world.page, topLevel, subOption)
+  const chosen = await pickRandomNonOtherCheckbox(world.page)
+  await checkCheckboxById(world.page, chosen.id)
+  await submitWhatActivityForm(world.page)
+  await completeActivityDetailsFromReview(
+    world,
+    `Site ${siteNumber} - Activity 1`
+  )
+}
+
+Given(
+  'the user opens the review site details page from the task list',
+  async function () {
+    await openReviewSiteDetailsFromTaskList(this)
+  }
+)
+
+When(
+  'the user changes the width of the circular site and continues',
+  async function () {
+    const review = new ReviewSiteDetailsPage(this.page)
+    await review.widthChangeLink().click()
+    await this.page.waitForLoadState('load')
+    await enterWidth(this.page, Number(this.data.site.width) + 25)
+    await this.page.waitForLoadState('load')
+    await continueFromReviewObservingRequery(this)
+  }
+)
+
+When('the user adds another circular site and continues', async function () {
+  await this.page
+    .locator('button[name="add"]:has-text("Add another site")')
+    .click()
+  await this.page.waitForLoadState('load')
+  await enterCircleSiteDetails(this, {
+    siteName: `Added Site ${faker.location.city()}`,
+    latitude: '51.500000',
+    longitude: '-2.000000',
+    width: '30'
+  })
+  await completeActivityForSite(this, 2)
+  await continueFromReviewObservingRequery(this)
+})
+
+When('the user changes the site name and continues', async function () {
+  const review = new ReviewSiteDetailsPage(this.page)
+  await review.siteNameChangeLink(1).click()
+  await this.page.waitForLoadState('load')
+  await this.page
+    .locator('#siteName')
+    .fill(`Renamed Site ${faker.location.city()}`)
+  await this.page.locator('button:has-text("Save and continue")').click()
+  await this.page.waitForLoadState('load')
+  await continueFromReviewObservingRequery(this)
+})
+
+Then('the marine plan policies are re-queried', async function () {
+  expect(this.data.requeried).toBe(true)
+})
+
+Then('the marine plan policies are not re-queried', async function () {
+  expect(this.data.requeried).toBe(false)
+})

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -592,43 +592,6 @@ export async function openReviewSiteDetailsFromTaskList(world) {
   await expectReviewSiteDetailsPage(world.page)
 }
 
-export async function continueFromReviewObservingRequery(world) {
-  const page = world.page
-  const reviewUrl = page.url()
-  // A material (geometry) change synchronously clears the previously-queried
-  // policies, so the Marine plan policy task reverts to "Cannot start yet"; an
-  // immaterial change (e.g. a rename) leaves the queried policies intact. This
-  // is a deterministic signal that a re-query is required, unlike the transient
-  // "Loading" page which can be missed when the policy job completes quickly.
-  await page.goto(
-    new URL('/marine-licence/task-list', getConfig().baseURL).toString()
-  )
-  await page.waitForLoadState('load')
-  const mppTask = (
-    await page
-      .locator('li.govuk-task-list__item', { hasText: 'Marine plan policy' })
-      .first()
-      .innerText()
-  )
-    .replace(/\s+/g, ' ')
-    .trim()
-  const requeried = /cannot start yet/i.test(mppTask)
-  // Complete the flow: continue from the review page (performs the re-query).
-  await page.goto(reviewUrl)
-  await page.waitForLoadState('load')
-  await page.locator('button:has-text("Continue")').click()
-  await page.waitForURL(/marine-licence\/task-list/, { timeout: 60_000 })
-  await page.waitForLoadState('load')
-  if (world.attach) {
-    world.attach(
-      `MPP task after change: "${mppTask}" (requeried: ${requeried})`,
-      'text/plain'
-    )
-  }
-  world.data.requeried = requeried
-  return requeried
-}
-
 export async function expectReviewSiteDetailsPage(page) {
   await expect(page.locator('h1').first()).toContainText(
     'Review site details',
@@ -780,8 +743,7 @@ export async function completeSiteDetailsViaFileUpload(
 
   await verifyActivityCardCompleted(world.page, 'Site 1 - Activity 1')
 
-  await world.page.locator('button:has-text("Continue")').click()
-  await world.page.waitForLoadState('load')
+  await finishSiteDetailsAndContinue(world.page)
 }
 
 async function completeNonSiteTasks(world, { wfd = 'nautical-no' } = {}) {
@@ -800,14 +762,27 @@ async function completeNonSiteTasks(world, { wfd = 'nautical-no' } = {}) {
   await completeFeeEstimate(world.page, 'Yes')
 }
 
+export async function finishSiteDetailsAndContinue(page, answer = 'yes') {
+  const radio = page.locator(
+    answer === 'no'
+      ? '#finishedEnteringSiteDetails-2'
+      : '#finishedEnteringSiteDetails'
+  )
+  if (await radio.count()) {
+    await radio.check()
+  }
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForURL(/marine-licence\/task-list/, { timeout: 60_000 })
+  await page.waitForLoadState('load')
+}
+
 async function addActivityForSite1AndContinue(world) {
   const { completeRandomActivityFromReviewPage } = await import(
     './lcml-activity-flow.js'
   )
   await completeRandomActivityFromReviewPage(world)
   await completeActivityDetailsFromReview(world, 'Site 1 - Activity 1')
-  await world.page.locator('button:has-text("Continue")').click()
-  await world.page.waitForLoadState('load')
+  await finishSiteDetailsAndContinue(world.page)
 }
 
 const POLYGON_COORDINATES = [

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -567,6 +567,51 @@ export async function submitPrimaryAndWait(page) {
   await page.waitForLoadState('load')
 }
 
+export async function openReviewSiteDetailsFromTaskList(world) {
+  // Once site details are completed the "Site details" task on the task list
+  // links straight to the review page.
+  await world.page.locator('a:has-text("Site details")').click()
+  await world.page.waitForLoadState('load')
+  await expectReviewSiteDetailsPage(world.page)
+}
+
+export async function continueFromReviewObservingRequery(world) {
+  const page = world.page
+  const reviewUrl = page.url()
+  // A material (geometry) change synchronously clears the previously-queried
+  // policies, so the Marine plan policy task reverts to "Cannot start yet"; an
+  // immaterial change (e.g. a rename) leaves the queried policies intact. This
+  // is a deterministic signal that a re-query is required, unlike the transient
+  // "Loading" page which can be missed when the policy job completes quickly.
+  await page.goto(
+    new URL('/marine-licence/task-list', getConfig().baseURL).toString()
+  )
+  await page.waitForLoadState('load')
+  const mppTask = (
+    await page
+      .locator('li.govuk-task-list__item', { hasText: 'Marine plan policy' })
+      .first()
+      .innerText()
+  )
+    .replace(/\s+/g, ' ')
+    .trim()
+  const requeried = /cannot start yet/i.test(mppTask)
+  // Complete the flow: continue from the review page (performs the re-query).
+  await page.goto(reviewUrl)
+  await page.waitForLoadState('load')
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForURL(/marine-licence\/task-list/, { timeout: 60_000 })
+  await page.waitForLoadState('load')
+  if (world.attach) {
+    world.attach(
+      `MPP task after change: "${mppTask}" (requeried: ${requeried})`,
+      'text/plain'
+    )
+  }
+  world.data.requeried = requeried
+  return requeried
+}
+
 export async function expectReviewSiteDetailsPage(page) {
   await expect(page.locator('h1').first()).toContainText(
     'Review site details',


### PR DESCRIPTION
Have you finished adding sites scenarios covered


Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/530
Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/814

