### PR TITLE
ML-1377: journey tests for marine plan policies on CYA/View details and Review-and-send 

### DIFF
--- a/test/features/lcml/lcml.check.your.answers.feature
+++ b/test/features/lcml/lcml.check.your.answers.feature
@@ -1,0 +1,33 @@
+@lcml
+Feature: LCML: Check your answers marine plan policies
+  As an applicant
+  I want to review and change my marine plan policy considerations on the Check your answers page
+  So that I can confirm my answers before sending my information
+
+  @issue=ML-1377
+  Scenario: Check your answers shows the marine plan policies summary card
+    Given an organisation user has completed a marine licence ready to review
+    When the user opens the check your answers page
+    Then the marine plan policies card is displayed beneath the site and activity cards
+    And the marine plan policies card lists the policies sorted by code with their wording and my response
+    And the marine plan policies card has a Change link for each policy
+
+  @issue=ML-1377
+  Scenario: Changing a marine plan policy from check your answers opens the pre-populated consideration page
+    Given an organisation user is on the check your answers page with completed marine plan policies
+    When the user selects Change for the first marine plan policy
+    Then the policy consideration page is pre-populated with my response and has no Cancel option
+
+  @issue=ML-1377
+  Scenario: Saving a changed marine plan policy returns to check your answers
+    Given an organisation user is on the check your answers page with completed marine plan policies
+    When the user selects Change for the first marine plan policy
+    And the user updates the consideration and selects Save and continue
+    Then the user is returned to the check your answers page
+
+  @issue=ML-1377
+  Scenario: Selecting Back from a marine plan policy consideration returns to check your answers
+    Given an organisation user is on the check your answers page with completed marine plan policies
+    When the user selects Change for the first marine plan policy
+    And the user selects Back on the policy consideration page
+    Then the user is returned to the check your answers page

--- a/test/features/lcml/lcml.marine.plan.policies.feature
+++ b/test/features/lcml/lcml.marine.plan.policies.feature
@@ -128,3 +128,15 @@ Feature: LCML: Marine plan policies
     When the user answers "No" and continues from the review page
     Then the "Marine plan policy considerations" task is "Cannot start yet" and is not a link
     And the "Site details" task has status "In progress"
+
+  @issue=ML-1377
+  Scenario: Review and send is hidden while the marine plan policy considerations are incomplete
+    Given an organisation user has completed the site details for a marine licence application
+    When the user views the marine licence task list
+    Then the Review and send your information button is not displayed
+
+  @issue=ML-1377
+  Scenario: Review and send is shown once the marine plan policy considerations are completed
+    Given an organisation user has completed the site details for a marine licence application
+    When the user completes the marine plan policy considerations and returns to the task list
+    Then the Review and send your information button is displayed

--- a/test/features/lcml/lcml.view.details.feature
+++ b/test/features/lcml/lcml.view.details.feature
@@ -16,6 +16,21 @@ Feature: LCML: View details page shows sites and activities
     Then the View details page shows the "File upload" site location method
     And the View details page shows an uploaded site card with a name and a map
 
+  @issue=ML-1377
+  Scenario: View details shows the marine plan policies summary card
+    Given an organisation user has submitted a marine licence application with marine plan policies
+    When the user opens View details for the submitted marine licence
+    Then the marine plan policies card is displayed beneath the site and activity cards
+    And the marine plan policies card lists the policies sorted by code with their wording and my response
+    And the marine plan policies card has no Change links
+
+  @issue=ML-1377
+  Scenario: Public View details shows the marine plan policies summary card
+    Given an organisation user has submitted a marine licence application with marine plan policies
+    When the user opens the public View details link for the submitted marine licence
+    Then the marine plan policies card is displayed beneath the site and activity cards
+    And the marine plan policies card has no Change links
+
   @real-defra-id @d365 @issue=ML-1407 @issue=ML-1375
   Scenario: A submitted marine licence case is shown in the D365 workbasket and case summary
     Given an organisation user has submitted a marine licence application with a site in a marine plan area

--- a/test/steps/lcml.mpp.display.steps.js
+++ b/test/steps/lcml.mpp.display.steps.js
@@ -1,0 +1,234 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  completeManualCircleApp,
+  submitMarineLicence,
+  completeMarinePlanPolicies,
+  MARINE_PLAN_POLICY_RESPONSE
+} from '../support/lcml-helpers.js'
+import { clickReviewAndSend } from '../support/task-flow.js'
+
+const MPP_CARD = '#marine-plan-policies-card'
+
+function policyRows(page) {
+  return page.locator(`${MPP_CARD} .govuk-summary-list__row`)
+}
+
+async function cardTitlesInOrder(page) {
+  return page
+    .locator('.govuk-summary-card__title')
+    .evaluateAll((titles) => titles.map((t) => t.textContent.trim()))
+}
+
+async function policyCodesInCard(page) {
+  return page
+    .locator(`${MPP_CARD} dt.govuk-summary-list__key`)
+    .evaluateAll((keys) => keys.map((k) => k.textContent.trim()))
+}
+
+// --- Givens ---
+
+Given(
+  'an organisation user has submitted a marine licence application with marine plan policies',
+  { timeout: 180_000 },
+  async function () {
+    await completeManualCircleApp(this)
+    await submitMarineLicence(this)
+  }
+)
+
+Given(
+  'an organisation user has completed a marine licence ready to review',
+  { timeout: 180_000 },
+  async function () {
+    await completeManualCircleApp(this)
+    await completeMarinePlanPolicies(this.page)
+  }
+)
+
+Given(
+  'an organisation user is on the check your answers page with completed marine plan policies',
+  { timeout: 180_000 },
+  async function () {
+    await completeManualCircleApp(this)
+    await clickReviewAndSend(this.page)
+    await expect(
+      this.page.locator('#check-your-answers-heading')
+    ).toContainText('Check your answers before sending your information', {
+      timeout: 30_000
+    })
+  }
+)
+
+When('the user opens the check your answers page', async function () {
+  await this.page.locator('#review-and-send').click()
+  await this.page.waitForURL(/marine-licence\/check-your-answers/, {
+    timeout: 30_000
+  })
+  await this.page.waitForLoadState('load')
+})
+
+// --- Shared Marine plan policies card assertions (View details + Check your answers) ---
+
+Then(
+  'the marine plan policies card is displayed beneath the site and activity cards',
+  async function () {
+    await expect(this.page.locator(MPP_CARD)).toBeVisible({ timeout: 30_000 })
+    await expect(
+      this.page.locator(`${MPP_CARD} .govuk-summary-card__title`)
+    ).toHaveText('Marine plan policies', { timeout: 30_000 })
+
+    const titles = await cardTitlesInOrder(this.page)
+    const mppIndex = titles.indexOf('Marine plan policies')
+    const lastSiteOrActivity = titles.reduce(
+      (last, title, index) => (/site|activity/i.test(title) ? index : last),
+      -1
+    )
+    expect(mppIndex).toBeGreaterThan(lastSiteOrActivity)
+  }
+)
+
+Then(
+  'the marine plan policies card lists the policies sorted by code with their wording and my response',
+  async function () {
+    const codes = await policyCodesInCard(this.page)
+    expect(codes.length).toBeGreaterThan(0)
+    expect(codes).toEqual([...codes].sort((a, b) => a.localeCompare(b)))
+
+    const rows = policyRows(this.page)
+    const count = await rows.count()
+    for (let i = 0; i < count; i++) {
+      const value = rows.nth(i).locator('.govuk-summary-list__value')
+      await expect(value).toContainText('Policy information', {
+        timeout: 30_000
+      })
+      await expect(value).toContainText('Your consideration', {
+        timeout: 30_000
+      })
+      await expect(value).toContainText(MARINE_PLAN_POLICY_RESPONSE, {
+        timeout: 30_000
+      })
+    }
+  }
+)
+
+Then('the marine plan policies card has no Change links', async function () {
+  await expect(
+    this.page.locator(`${MPP_CARD} .govuk-summary-list__actions a`)
+  ).toHaveCount(0)
+})
+
+Then(
+  'the marine plan policies card has a Change link for each policy',
+  async function () {
+    const rowCount = await policyRows(this.page).count()
+    const changeLinks = this.page.locator(
+      `${MPP_CARD} .govuk-summary-list__actions a`
+    )
+    await expect(changeLinks).toHaveCount(rowCount)
+    await expect(changeLinks.first()).toContainText('Change')
+  }
+)
+
+// --- AC2: Review and send button gating ---
+
+Then(
+  'the Review and send your information button is not displayed',
+  async function () {
+    await expect(this.page).toHaveURL(/marine-licence\/task-list/, {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('#review-and-send')).toHaveCount(0)
+  }
+)
+
+When(
+  'the user completes the marine plan policy considerations and returns to the task list',
+  { timeout: 120_000 },
+  async function () {
+    await completeMarinePlanPolicies(this.page)
+  }
+)
+
+Then(
+  'the Review and send your information button is displayed',
+  async function () {
+    await expect(this.page).toHaveURL(/marine-licence\/task-list/, {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('#review-and-send')).toBeVisible({
+      timeout: 30_000
+    })
+  }
+)
+
+// --- AC4: Change a marine plan policy from Check your answers ---
+
+When(
+  'the user selects Change for the first marine plan policy',
+  async function () {
+    const firstChange = this.page
+      .locator(`${MPP_CARD} .govuk-summary-list__actions a`)
+      .first()
+    const href = await firstChange.getAttribute('href')
+    this.data.policyCode = href.split('/').pop()
+    await firstChange.click()
+    await this.page.waitForURL(
+      new RegExp(`marine-plan-policy/${this.data.policyCode}$`),
+      { timeout: 30_000 }
+    )
+  }
+)
+
+Then(
+  'the policy consideration page is pre-populated with my response and has no Cancel option',
+  async function () {
+    await expect(this.page.locator('#policyConsideration')).toHaveValue(
+      MARINE_PLAN_POLICY_RESPONSE,
+      { timeout: 30_000 }
+    )
+    await expect(
+      this.page.locator('a.govuk-back-link:has-text("Back")')
+    ).toBeVisible({ timeout: 30_000 })
+    await expect(
+      this.page.locator('button:has-text("Save and continue")')
+    ).toBeVisible({ timeout: 30_000 })
+    await expect(
+      this.page.getByRole('link', { name: 'Cancel', exact: true })
+    ).toHaveCount(0)
+    await expect(
+      this.page.getByRole('button', { name: 'Cancel', exact: true })
+    ).toHaveCount(0)
+  }
+)
+
+When(
+  'the user updates the consideration and selects Save and continue',
+  async function () {
+    this.data.updatedResponse = `Updated consideration ${faker.lorem.sentence(6)}`
+    await this.page
+      .locator('#policyConsideration')
+      .fill(this.data.updatedResponse)
+    await this.page.locator('button:has-text("Save and continue")').click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+When(
+  'the user selects Back on the policy consideration page',
+  async function () {
+    await this.page.locator('a.govuk-back-link:has-text("Back")').click()
+    await this.page.waitForLoadState('load')
+  }
+)
+
+Then('the user is returned to the check your answers page', async function () {
+  await expect(this.page).toHaveURL(/marine-licence\/check-your-answers/, {
+    timeout: 30_000
+  })
+  await expect(this.page.locator('#check-your-answers-heading')).toContainText(
+    'Check your answers before sending your information',
+    { timeout: 30_000 }
+  )
+})

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -28,6 +28,9 @@ import WaterFrameworkDirectivePage from '../pages/water.framework.directive.page
 
 export const WFD_ASSESSMENT_FILE = 'test/resources/WFD.odt'
 
+export const MARINE_PLAN_POLICY_RESPONSE =
+  'We have considered this policy and the proposal is compatible with it.'
+
 const SAMPLE_FILES = {
   KML: 'test/resources/EXE_2025_00009-LOCATIONS.kml',
   Shapefile: 'test/resources/valid-shapefile.zip'
@@ -899,11 +902,7 @@ export async function completeMarinePlanPolicies(page) {
     await page.waitForURL(new RegExp(`marine-plan-policy/${code}$`), {
       timeout: 30_000
     })
-    await page
-      .locator('#policyConsideration')
-      .fill(
-        'We have considered this policy and the proposal is compatible with it.'
-      )
+    await page.locator('#policyConsideration').fill(MARINE_PLAN_POLICY_RESPONSE)
     await page.locator('button:has-text("Save and continue")').click()
     await page.waitForURL(/marine-licence\/marine-plan-policies/, {
       timeout: 30_000


### PR DESCRIPTION
Adds journey-test coverage for ML-1377 — displaying the marine plan policies on the Check your answers and View 
