### PR TITLE
Attach failure timestamp and harden task-list/review-page flakes

### DIFF
--- a/test/support/hooks.js
+++ b/test/support/hooks.js
@@ -13,6 +13,18 @@ import { expireTestUser } from './auth.js'
 
 setDefaultTimeout(120_000)
 
+function failingStepWindowText(duration) {
+  const failedAt = new Date()
+  const durationMs =
+    Number(duration?.seconds ?? 0) * 1000 + Number(duration?.nanos ?? 0) / 1e6
+  const startedAt = new Date(failedAt.getTime() - durationMs)
+  return [
+    `Failing step started at: ${startedAt.toISOString()} (UTC)`,
+    `Failing step failed at:  ${failedAt.toISOString()} (UTC)`,
+    `Failing step duration:   ${(durationMs / 1000).toFixed(1)}s`
+  ].join('\n')
+}
+
 let browser
 
 BeforeAll(async function () {
@@ -44,6 +56,7 @@ Before(async function (scenario) {
 // is collapsed by default and effectively invisible in the Allure report.
 AfterStep(async function ({ result }) {
   if (result.status === Status.FAILED && this.page && !this.page.isClosed()) {
+    this.attach(failingStepWindowText(result.duration), 'text/plain')
     const screenshot = await this.page.screenshot({ fullPage: true })
     this.attach(screenshot, 'image/png')
     this.attach(`Failure URL: ${this.page.url()}`, 'text/plain')
@@ -72,6 +85,10 @@ After(async function (scenario) {
     this.page &&
     !this.page.isClosed()
   ) {
+    this.attach(
+      `Failure captured at: ${new Date().toISOString()} (UTC)`,
+      'text/plain'
+    )
     const screenshot = await this.page.screenshot({ fullPage: true })
     this.attach(screenshot, 'image/png')
     this.attach(`Failure URL: ${this.page.url()}`, 'text/plain')

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -101,7 +101,13 @@ export async function loginAndStartApplication(world, role = 'employee') {
   await world.page.waitForLoadState('load')
 }
 
+export async function waitForTaskList(page) {
+  await page.waitForURL(/marine-licence\/task-list/, { timeout: 30_000 })
+  await page.waitForLoadState('load')
+}
+
 export async function completeSpecialLegalPowers(page, answer) {
+  await waitForTaskList(page)
   await expect(page.locator('h2:has-text("Other permissions")')).toBeVisible({
     timeout: 30_000
   })
@@ -215,7 +221,7 @@ export async function completeProjectBackground(page, text) {
 
   await page.locator('#projectBackground').fill(text)
   await page.locator('button:has-text("Save and continue")').click()
-  await page.waitForLoadState('load')
+  await waitForTaskList(page)
 }
 
 export async function completeWaterFrameworkDirective(page, answer = 'No') {
@@ -345,6 +351,10 @@ export async function clickCardLinkAndAwaitNavigation(page, link) {
 }
 
 async function clickAddLinkInActivityCard(page, cardTitle, rowName) {
+  await page.waitForURL(/review-site-details/, { timeout: 30_000 })
+  await expect(activityCardLocator(page, cardTitle)).toBeVisible({
+    timeout: 30_000
+  })
   await clickCardLinkAndAwaitNavigation(
     page,
     activityCardLocator(page, cardTitle)


### PR DESCRIPTION
Attach the failing step's UTC time window to failure evidence so CDP pipeline failures can be correlated with 
wait for the task list to settle before asserting its sections
wait for the review page and activity card to render before clicking activity-detail Add links.


