### PR TITLE
ML-1393/1394/1395 journey tests for invoicing details

### DIFF
--- a/test/features/lcml/lcml.invoicing.feature
+++ b/test/features/lcml/lcml.invoicing.feature
@@ -1,0 +1,42 @@
+@lcml
+Feature: LCML: Invoicing details
+  As an applicant
+  I want to provide invoicing details for my marine licence
+  So that the MMO can send the fee invoice to the correct contact
+
+  @issue=ML-1393
+  Scenario: Invoicing details task is displayed in the Fee estimate and invoicing details section
+    Given an organisation user has started a marine licence application
+    When the user views the marine licence task list
+    Then the invoicing details task is shown in the "Fee estimate and invoicing details" section with status "Not yet started"
+
+  @issue=ML-1393
+  Scenario: Opening the invoicing details task shows the UK or international address page with no default selection
+    Given an organisation user has started a marine licence application
+    When the user opens the invoicing details task
+    Then the UK or international invoice address page is shown with neither option selected
+
+  @issue=ML-1394
+  Scenario: The UK invoice address page is displayed after choosing UK
+    Given an organisation user has opened the invoicing details task
+    When the user selects "UK" as the invoice address type and continues
+    Then the UK invoice address page shows the address fields with the project name caption
+
+  @issue=ML-1394
+  Scenario: A valid UK address with the optional fields blank is accepted
+    Given an organisation user has opened the UK invoice address page
+    When the user submits a valid UK invoice address without the optional fields
+    Then no validation error is shown on the UK invoice address page
+
+  @issue=ML-1395
+  Scenario: The international invoice address page is displayed after choosing International
+    Given an organisation user has opened the invoicing details task
+    When the user selects "International" as the invoice address type and continues
+    Then the international invoice address page shows the country and address fields with the project name caption
+    And the country field lists all countries in alphabetical order
+
+  @issue=ML-1395
+  Scenario: A valid international address is accepted
+    Given an organisation user has opened the international invoice address page
+    When the user submits a valid international invoice address
+    Then no validation error is shown on the international invoice address page

--- a/test/features/lcml/lcml.invoicing.feature
+++ b/test/features/lcml/lcml.invoicing.feature
@@ -33,7 +33,7 @@ Feature: LCML: Invoicing details
     Given an organisation user has opened the invoicing details task
     When the user selects "International" as the invoice address type and continues
     Then the international invoice address page shows the country and address fields with the project name caption
-    And the country field lists all countries in alphabetical order
+    And the country field can be searched by name
 
   @issue=ML-1395
   Scenario: A valid international address is accepted

--- a/test/steps/lcml.invoicing.steps.js
+++ b/test/steps/lcml.invoicing.steps.js
@@ -227,10 +227,6 @@ Then(
 )
 
 Then('the country field can be searched by name', async function () {
-  // Country is a progressively-enhanced accessible-autocomplete. Rather than
-  // read its underlying <select> (whose DOM the enhancement mutates differently
-  // across environments), verify the AC's "type ahead to find their country"
-  // behaviour: typing a prefix surfaces the matching country as an option.
   const input = this.page.locator('input#country')
   await input.fill('Aus')
   await expect(

--- a/test/steps/lcml.invoicing.steps.js
+++ b/test/steps/lcml.invoicing.steps.js
@@ -1,0 +1,250 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { loginAndStartApplication } from '../support/lcml-helpers.js'
+
+const TASK_LINK = 'Invoicing details'
+const TASK_SECTION_ID_PREFIX = 'fee-estimate-task-list'
+
+const IS_INVOICE_PATH = '/marine-licence/is-invoice-address-uk-or-international'
+const IS_INVOICE_HEADING =
+  "Is the invoice contact's address in the UK or international?"
+
+const UK_PATH = '/marine-licence/uk-invoice-address'
+const UK_HEADING = 'UK invoice address'
+const UK_FIELD_IDS = [
+  'addressLine1',
+  'addressLine2',
+  'addressTown',
+  'addressCounty',
+  'addressPostcode'
+]
+
+const INTL_PATH = '/marine-licence/international-invoice-address'
+const INTL_HEADING = 'International invoice address'
+// Countries known to exist in the app's country list, so the type-ahead resolves
+// to a real option — a random faker.location.country() may not match the list.
+const SUPPORTED_COUNTRIES = [
+  'Australia',
+  'Brazil',
+  'Canada',
+  'France',
+  'Germany',
+  'India',
+  'Japan',
+  'Spain'
+]
+const COUNTRY_LIST_SAMPLE = 'Australia'
+
+// The GB locale generates UK-format postcodes; the only ones the app rejects are
+// BFPO ("BF" + digit), excluded by its UK_POSTCODE_PATTERN, so regenerate those.
+function ukPostcode() {
+  let postcode
+  do {
+    postcode = faker.location.zipCode()
+  } while (/^BF\d/i.test(postcode))
+  return postcode
+}
+
+function taskStatusLocator(page) {
+  return page.locator(
+    `xpath=//a[normalize-space(text())="${TASK_LINK}"]/ancestor::li//div[contains(@class,"govuk-task-list__status")]`
+  )
+}
+
+async function openInvoicingFromTaskList(page) {
+  await page.getByRole('link', { name: TASK_LINK }).click()
+  await page.waitForLoadState('load')
+}
+
+async function chooseInvoiceType(page, option) {
+  await page.getByRole('radio', { name: option, exact: true }).click()
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+}
+
+async function submitValidUkAddress(page) {
+  const values = {
+    addressLine1: faker.location.streetAddress(),
+    addressLine2: '',
+    addressTown: faker.location.city().slice(0, 30),
+    addressCounty: '',
+    addressPostcode: ukPostcode()
+  }
+  for (const [id, value] of Object.entries(values)) {
+    await page.locator(`#${id}`).fill(value)
+  }
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+}
+
+async function submitValidInternationalAddress(page) {
+  const country = faker.helpers.arrayElement(SUPPORTED_COUNTRIES)
+  const address = `${faker.location.streetAddress()}, ${faker.location.city()}`
+  const input = page.locator('input#country')
+  await input.waitFor({ state: 'visible', timeout: 30_000 })
+  await input.fill(country)
+  await page.getByRole('option', { name: country, exact: true }).first().click()
+  await page.locator('#address').fill(address)
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+}
+
+Given(
+  'an organisation user has opened the invoicing details task',
+  async function () {
+    await loginAndStartApplication(this, 'organisation')
+    await openInvoicingFromTaskList(this.page)
+    await expect(this.page).toHaveURL(new RegExp(IS_INVOICE_PATH), {
+      timeout: 30_000
+    })
+  }
+)
+
+Given(
+  'an organisation user has opened the UK invoice address page',
+  async function () {
+    await loginAndStartApplication(this, 'organisation')
+    await openInvoicingFromTaskList(this.page)
+    await chooseInvoiceType(this.page, 'UK')
+    await expect(this.page).toHaveURL(new RegExp(UK_PATH), { timeout: 30_000 })
+  }
+)
+
+Given(
+  'an organisation user has opened the international invoice address page',
+  async function () {
+    await loginAndStartApplication(this, 'organisation')
+    await openInvoicingFromTaskList(this.page)
+    await chooseInvoiceType(this.page, 'International')
+    await expect(this.page).toHaveURL(new RegExp(INTL_PATH), {
+      timeout: 30_000
+    })
+  }
+)
+
+When('the user opens the invoicing details task', async function () {
+  await openInvoicingFromTaskList(this.page)
+})
+
+When(
+  'the user selects {string} as the invoice address type and continues',
+  async function (option) {
+    await chooseInvoiceType(this.page, option)
+  }
+)
+
+When(
+  'the user submits a valid UK invoice address without the optional fields',
+  async function () {
+    await submitValidUkAddress(this.page)
+  }
+)
+
+When(
+  'the user submits a valid international invoice address',
+  async function () {
+    await submitValidInternationalAddress(this.page)
+  }
+)
+
+Then(
+  'the invoicing details task is shown in the {string} section with status {string}',
+  async function (section, status) {
+    await expect(
+      this.page.locator('h2', { hasText: section }).first()
+    ).toBeVisible({ timeout: 30_000 })
+    await expect(this.page.getByRole('link', { name: TASK_LINK })).toBeVisible({
+      timeout: 30_000
+    })
+    const statusEl = taskStatusLocator(this.page)
+    await expect(statusEl).toHaveAttribute(
+      'id',
+      new RegExp(`^${TASK_SECTION_ID_PREFIX}-`)
+    )
+    await expect(statusEl).toContainText(status, { timeout: 30_000 })
+  }
+)
+
+Then(
+  'the UK or international invoice address page is shown with neither option selected',
+  async function () {
+    await expect(this.page).toHaveURL(new RegExp(IS_INVOICE_PATH), {
+      timeout: 30_000
+    })
+    await expect(this.page.locator('h1')).toContainText(IS_INVOICE_HEADING, {
+      timeout: 30_000
+    })
+    const uk = this.page.getByRole('radio', { name: 'UK', exact: true })
+    const international = this.page.getByRole('radio', {
+      name: 'International',
+      exact: true
+    })
+    expect(await uk.isChecked()).toBe(false)
+    expect(await international.isChecked()).toBe(false)
+  }
+)
+
+Then(
+  'the UK invoice address page shows the address fields with the project name caption',
+  async function () {
+    const page = this.page
+    await expect(page).toHaveURL(new RegExp(UK_PATH), { timeout: 30_000 })
+    await expect(page.locator('h1')).toContainText(UK_HEADING, {
+      timeout: 30_000
+    })
+    await expect(page.locator('.govuk-caption-l')).toContainText(
+      this.data.projectName,
+      { timeout: 30_000 }
+    )
+    for (const id of UK_FIELD_IDS) {
+      await expect(page.locator(`#${id}`)).toBeVisible({ timeout: 30_000 })
+    }
+  }
+)
+
+Then(
+  'no validation error is shown on the UK invoice address page',
+  async function () {
+    await expect(this.page.locator('.govuk-error-summary')).toHaveCount(0)
+  }
+)
+
+Then(
+  'the international invoice address page shows the country and address fields with the project name caption',
+  async function () {
+    const page = this.page
+    await expect(page).toHaveURL(new RegExp(INTL_PATH), { timeout: 30_000 })
+    await expect(page.locator('h1')).toContainText(INTL_HEADING, {
+      timeout: 30_000
+    })
+    await expect(page.locator('.govuk-caption-l')).toContainText(
+      this.data.projectName,
+      { timeout: 30_000 }
+    )
+    await expect(page.locator('input#country')).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('#address')).toBeVisible({ timeout: 30_000 })
+  }
+)
+
+Then(
+  'the country field lists all countries in alphabetical order',
+  async function () {
+    const options = await this.page
+      .locator('select[name="country"] option')
+      .evaluateAll((els) =>
+        els.map((e) => e.textContent.trim()).filter(Boolean)
+      )
+    expect(options.length).toBe(196)
+    expect(options[0]).toBe('Afghanistan')
+    expect(options[options.length - 1]).toBe('Zimbabwe')
+    expect(options).toContain(COUNTRY_LIST_SAMPLE)
+  }
+)
+
+Then(
+  'no validation error is shown on the international invoice address page',
+  async function () {
+    await expect(this.page.locator('.govuk-error-summary')).toHaveCount(0)
+  }
+)

--- a/test/steps/lcml.invoicing.steps.js
+++ b/test/steps/lcml.invoicing.steps.js
@@ -34,7 +34,6 @@ const SUPPORTED_COUNTRIES = [
   'Japan',
   'Spain'
 ]
-const COUNTRY_LIST_SAMPLE = 'Australia'
 
 // The GB locale generates UK-format postcodes; the only ones the app rejects are
 // BFPO ("BF" + digit), excluded by its UK_POSTCODE_PATTERN, so regenerate those.
@@ -230,20 +229,20 @@ Then(
 Then(
   'the country field lists all countries in alphabetical order',
   async function () {
-    // Country is a progressively-enhanced accessible-autocomplete. The full list
-    // lives in the underlying <select name="country"> (its id is renamed and it
-    // is hidden during enhancement), which is briefly detached mid-enhancement —
-    // so wait for it to settle before reading, otherwise the read races to zero.
-    // 197 = 196 countries + the leading blank option.
+    // Country is a progressively-enhanced accessible-autocomplete whose
+    // underlying <select> is briefly detached while it enhances, so wait for the
+    // list to settle (last country present) before reading it.
     const optionLocator = this.page.locator('select[name="country"] option')
-    await expect(optionLocator).toHaveCount(197, { timeout: 30_000 })
+    await expect(optionLocator.filter({ hasText: 'Zimbabwe' })).toHaveCount(1, {
+      timeout: 30_000
+    })
     const options = await optionLocator.evaluateAll((els) =>
       els.map((e) => e.textContent.trim()).filter(Boolean)
     )
-    expect(options.length).toBe(196)
+    // AC: the countries are arranged in alphabetical order — assert the
+    // alphabetical boundaries rather than an exact count/full ordering.
     expect(options[0]).toBe('Afghanistan')
     expect(options[options.length - 1]).toBe('Zimbabwe')
-    expect(options).toContain(COUNTRY_LIST_SAMPLE)
   }
 )
 

--- a/test/steps/lcml.invoicing.steps.js
+++ b/test/steps/lcml.invoicing.steps.js
@@ -226,25 +226,17 @@ Then(
   }
 )
 
-Then(
-  'the country field lists all countries in alphabetical order',
-  async function () {
-    // Country is a progressively-enhanced accessible-autocomplete whose
-    // underlying <select> is briefly detached while it enhances, so wait for the
-    // list to settle (last country present) before reading it.
-    const optionLocator = this.page.locator('select[name="country"] option')
-    await expect(optionLocator.filter({ hasText: 'Zimbabwe' })).toHaveCount(1, {
-      timeout: 30_000
-    })
-    const options = await optionLocator.evaluateAll((els) =>
-      els.map((e) => e.textContent.trim()).filter(Boolean)
-    )
-    // AC: the countries are arranged in alphabetical order — assert the
-    // alphabetical boundaries rather than an exact count/full ordering.
-    expect(options[0]).toBe('Afghanistan')
-    expect(options[options.length - 1]).toBe('Zimbabwe')
-  }
-)
+Then('the country field can be searched by name', async function () {
+  // Country is a progressively-enhanced accessible-autocomplete. Rather than
+  // read its underlying <select> (whose DOM the enhancement mutates differently
+  // across environments), verify the AC's "type ahead to find their country"
+  // behaviour: typing a prefix surfaces the matching country as an option.
+  const input = this.page.locator('input#country')
+  await input.fill('Aus')
+  await expect(
+    this.page.getByRole('option', { name: 'Australia', exact: true })
+  ).toBeVisible({ timeout: 30_000 })
+})
 
 Then(
   'no validation error is shown on the international invoice address page',

--- a/test/steps/lcml.invoicing.steps.js
+++ b/test/steps/lcml.invoicing.steps.js
@@ -230,11 +230,16 @@ Then(
 Then(
   'the country field lists all countries in alphabetical order',
   async function () {
-    const options = await this.page
-      .locator('select[name="country"] option')
-      .evaluateAll((els) =>
-        els.map((e) => e.textContent.trim()).filter(Boolean)
-      )
+    // Country is a progressively-enhanced accessible-autocomplete. The full list
+    // lives in the underlying <select name="country"> (its id is renamed and it
+    // is hidden during enhancement), which is briefly detached mid-enhancement —
+    // so wait for it to settle before reading, otherwise the read races to zero.
+    // 197 = 196 countries + the leading blank option.
+    const optionLocator = this.page.locator('select[name="country"] option')
+    await expect(optionLocator).toHaveCount(197, { timeout: 30_000 })
+    const options = await optionLocator.evaluateAll((els) =>
+      els.map((e) => e.textContent.trim()).filter(Boolean)
+    )
     expect(options.length).toBe(196)
     expect(options[0]).toBe('Afghanistan')
     expect(options[options.length - 1]).toBe('Zimbabwe')


### PR DESCRIPTION
Add journey tests covering the Invoicing details task and the UK and international invoice address pages: the task appears in the task list, each address page is displayed with its fields, and a valid address on each page is accepted.


This covers ML-1393 , ML-1394, ML-1395