### PR TITLE
ML-1396: complete the invoicing task before Review and send

### DIFF
--- a/test/steps/lcml.apply.steps.js
+++ b/test/steps/lcml.apply.steps.js
@@ -14,6 +14,7 @@ import {
   completeWaterFrameworkDirective,
   completeFeeEstimate,
   completeMarinePlanPolicies,
+  ensureReadyForReviewAndSend,
   pickRandomFileType
 } from '../support/lcml-helpers.js'
 
@@ -99,6 +100,7 @@ When(
   async function () {
     // Task list → Check your answers
     await completeMarinePlanPolicies(this.page)
+    await ensureReadyForReviewAndSend(this.page)
     await this.page.locator('#review-and-send').click()
     await this.page.waitForLoadState('load')
     await expect(

--- a/test/steps/lcml.mpp.display.steps.js
+++ b/test/steps/lcml.mpp.display.steps.js
@@ -5,6 +5,7 @@ import {
   completeManualCircleApp,
   submitMarineLicence,
   completeMarinePlanPolicies,
+  ensureReadyForReviewAndSend,
   MARINE_PLAN_POLICY_RESPONSE
 } from '../support/lcml-helpers.js'
 import { clickReviewAndSend } from '../support/task-flow.js'
@@ -62,6 +63,7 @@ Given(
 )
 
 When('the user opens the check your answers page', async function () {
+  await ensureReadyForReviewAndSend(this.page)
   await this.page.locator('#review-and-send').click()
   await this.page.waitForURL(/marine-licence\/check-your-answers/, {
     timeout: 30_000
@@ -148,6 +150,7 @@ When(
   { timeout: 120_000 },
   async function () {
     await completeMarinePlanPolicies(this.page)
+    await ensureReadyForReviewAndSend(this.page)
   }
 )
 

--- a/test/steps/lcml.pre.application.consultation.steps.js
+++ b/test/steps/lcml.pre.application.consultation.steps.js
@@ -2,7 +2,8 @@ import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import {
   loginAndStartApplication,
-  completeMarinePlanPolicies
+  completeMarinePlanPolicies,
+  ensureReadyForReviewAndSend
 } from '../support/lcml-helpers.js'
 
 const TASK_LINK = 'Pre-application consultation'
@@ -160,6 +161,7 @@ When(
   'the user opens the check your answers page from the task list',
   async function () {
     await completeMarinePlanPolicies(this.page)
+    await ensureReadyForReviewAndSend(this.page)
     await this.page.locator('#review-and-send').click()
     await this.page.waitForLoadState('load')
     await expect(this.page.locator('#check-your-answers-heading')).toBeVisible({

--- a/test/steps/lcml.water.framework.directive.steps.js
+++ b/test/steps/lcml.water.framework.directive.steps.js
@@ -5,6 +5,7 @@ import {
   completeManualCircleApp,
   submitMarineLicence,
   completeMarinePlanPolicies,
+  ensureReadyForReviewAndSend,
   WFD_ASSESSMENT_FILE
 } from '../support/lcml-helpers.js'
 import WaterFrameworkDirectivePage from '../pages/water.framework.directive.page.js'
@@ -155,6 +156,7 @@ Given(
 
 When('the user opens the Check your answers page', async function () {
   await completeMarinePlanPolicies(this.page)
+  await ensureReadyForReviewAndSend(this.page)
   await this.page.locator('#review-and-send').click()
   await this.page.waitForLoadState('load')
 })

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -916,9 +916,72 @@ export async function completeMarinePlanPolicies(page) {
   await page.waitForURL(/marine-licence\/task-list/, { timeout: 30_000 })
 }
 
+// Completes the Invoicing details task from the task list. The flow gained
+// contact-details, purchase-order and check pages (ML-1396+); each page is
+// completed only if it appears, so this also works against older builds where
+// the flow stops earlier.
+export async function completeInvoicingDetails(page) {
+  await page.getByRole('link', { name: 'Invoicing details' }).click()
+  await page.waitForLoadState('load')
+
+  await page.getByRole('radio', { name: 'UK', exact: true }).click()
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+
+  await page.locator('#addressLine1').fill('1 Test Street')
+  await page.locator('#addressTown').fill('London')
+  await page.locator('#addressPostcode').fill('SW1A 1AA')
+  await page.locator('button:has-text("Continue")').click()
+  await page.waitForLoadState('load')
+
+  if (await page.locator('#fullName').count()) {
+    await page.locator('#fullName').fill('Invoice Contact')
+    // Organisation name is not shown for individual users.
+    if (await page.locator('#organisationName').count()) {
+      await page.locator('#organisationName').fill('Windfarm Co')
+    }
+    await page.locator('#phoneNumber').fill('01234567890')
+    await page.locator('#emailAddress').fill('invoice@example.com')
+    await page.locator('button:has-text("Continue")').click()
+    await page.waitForLoadState('load')
+  }
+
+  if (await page.locator('input[name="requiresPurchaseOrder"]').count()) {
+    await page
+      .locator('input[name="requiresPurchaseOrder"][value="no"]')
+      .check()
+    await page.locator('button:has-text("Continue")').click()
+    await page.waitForLoadState('load')
+  }
+
+  if (/check-invoicing-details/.test(page.url())) {
+    await page.locator('button:has-text("Continue")').click()
+    await page.waitForLoadState('load')
+  }
+
+  await page.waitForURL(/marine-licence\/task-list/, { timeout: 30_000 })
+}
+
+// The Invoicing details task gates "Review and send" from ML-1396 onwards. If
+// the button is missing after the other tasks are done, complete invoicing so
+// the button appears. On builds where invoicing is not gating, the button is
+// already present and this is a no-op.
+export async function ensureReadyForReviewAndSend(page) {
+  if (await page.locator('#review-and-send').count()) {
+    return
+  }
+  // Only the marine licence task list has an Invoicing details task that can
+  // gate the button; skip elsewhere (e.g. the exemption flow).
+  if (!(await page.getByRole('link', { name: 'Invoicing details' }).count())) {
+    return
+  }
+  await completeInvoicingDetails(page)
+}
+
 export async function submitMarineLicence(world) {
   const page = world.page
   await completeMarinePlanPolicies(page)
+  await ensureReadyForReviewAndSend(page)
   await page.locator('#review-and-send').click()
   await page.waitForLoadState('load')
   await page.locator('button:has-text("Continue")').click()

--- a/test/support/lcml-helpers.js
+++ b/test/support/lcml-helpers.js
@@ -916,10 +916,6 @@ export async function completeMarinePlanPolicies(page) {
   await page.waitForURL(/marine-licence\/task-list/, { timeout: 30_000 })
 }
 
-// Completes the Invoicing details task from the task list. The flow gained
-// contact-details, purchase-order and check pages (ML-1396+); each page is
-// completed only if it appears, so this also works against older builds where
-// the flow stops earlier.
 export async function completeInvoicingDetails(page) {
   await page.getByRole('link', { name: 'Invoicing details' }).click()
   await page.waitForLoadState('load')
@@ -936,7 +932,6 @@ export async function completeInvoicingDetails(page) {
 
   if (await page.locator('#fullName').count()) {
     await page.locator('#fullName').fill('Invoice Contact')
-    // Organisation name is not shown for individual users.
     if (await page.locator('#organisationName').count()) {
       await page.locator('#organisationName').fill('Windfarm Co')
     }
@@ -962,10 +957,6 @@ export async function completeInvoicingDetails(page) {
   await page.waitForURL(/marine-licence\/task-list/, { timeout: 30_000 })
 }
 
-// The Invoicing details task gates "Review and send" from ML-1396 onwards. If
-// the button is missing after the other tasks are done, complete invoicing so
-// the button appears. On builds where invoicing is not gating, the button is
-// already present and this is a no-op.
 export async function ensureReadyForReviewAndSend(page) {
   if (await page.locator('#review-and-send').count()) {
     return

--- a/test/support/task-flow.js
+++ b/test/support/task-flow.js
@@ -1,6 +1,9 @@
 import { navigateAndAuthenticate } from './navigation.js'
 import { completeSiteDetailsFlow } from './site-details-flow.js'
-import { completeMarinePlanPolicies } from './lcml-helpers.js'
+import {
+  completeMarinePlanPolicies,
+  ensureReadyForReviewAndSend
+} from './lcml-helpers.js'
 import ProjectNamePage from '../pages/project.name.page.js'
 import TaskListPage from '../pages/task.list.page.js'
 import PublicRegisterPage from '../pages/public.register.page.js'
@@ -60,6 +63,7 @@ export async function navigateAndCompleteSiteDetailsToReview(world) {
 
 export async function clickReviewAndSend(page) {
   await completeMarinePlanPolicies(page)
+  await ensureReadyForReviewAndSend(page)
   const taskList = new TaskListPage(page)
   await taskList.getReviewAndSendButton().click()
   await page.waitForLoadState('load')


### PR DESCRIPTION
ML-1396  updating the existing test for invoicing required for review

Depends-On: https://github.com/DEFRA/marine-licensing-backend/pull/545
Depends-On: https://github.com/DEFRA/marine-licensing-frontend/pull/825
