### PR TITLE
send gateway token and queue requests through the CDP Squid proxy

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -128,6 +128,8 @@ services:
 
   mongodb:
     image: mongo:7.0.24
+    ports:
+      - '27017:27017'
     volumes:
       - ./docker/scripts/mongodb:/docker-entrypoint-initdb.d
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "3.1107.0",
         "allure-commandline": "2.34.1",
-        "date-fns": "4.1.0"
+        "date-fns": "4.1.0",
+        "undici": "8.10.0"
       },
       "devDependencies": {
         "@cucumber/cucumber": "12.6.0",
@@ -6356,6 +6357,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "3.1107.0",
     "allure-commandline": "2.34.1",
-    "date-fns": "4.1.0"
+    "date-fns": "4.1.0",
+    "undici": "8.10.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "12.6.0",

--- a/test/support/config.js
+++ b/test/support/config.js
@@ -19,6 +19,10 @@ function getDefraIdUrl() {
 
 const cdpEnvironments = ['dev', 'test']
 
+// Squid sidecar in CDP. Chromium uses this via --proxy-server; Node fetch
+// must use the same URL via undici ProxyAgent (it ignores --proxy-server).
+export const CDP_PROXY_URL = 'http://localhost:3128'
+
 function isCdpEnvironment() {
   return cdpEnvironments.includes(environment)
 }
@@ -32,7 +36,7 @@ function getChromiumArgs() {
 
   if (isCdpEnvironment()) {
     args.push(
-      '--proxy-server=http://localhost:3128',
+      `--proxy-server=${CDP_PROXY_URL}`,
       '--ignore-certificate-errors',
       '--disable-dev-shm-usage'
     )

--- a/test/support/config.js
+++ b/test/support/config.js
@@ -36,7 +36,7 @@ function getChromiumArgs() {
 
   if (isCdpEnvironment()) {
     args.push(
-      `--proxy-server=${CDP_PROXY_URL}`,
+      '--proxy-server=' + CDP_PROXY_URL,
       '--ignore-certificate-errors',
       '--disable-dev-shm-usage'
     )

--- a/test/support/mas-queue.js
+++ b/test/support/mas-queue.js
@@ -3,6 +3,8 @@ import {
   GetQueueUrlCommand,
   SendMessageCommand
 } from '@aws-sdk/client-sqs'
+import { ProxyAgent, fetch } from 'undici'
+import { CDP_PROXY_URL } from './config.js'
 
 // Builds the message Dynamics 365 posts when an application transfer to MCMS is
 // completed. The backend's MAS worker consumes it and sets the marine licence
@@ -53,6 +55,16 @@ async function sendViaLocalStack(message) {
 const DEFAULT_GATEWAY_TOKEN_URL =
   'https://marine-licensing-backend-6bf3a.auth.eu-west-2.amazoncognito.com/oauth2/token'
 
+// Force token and /queue calls through the CDP Squid sidecar, matching
+// Chromium's --proxy-server. Native fetch does not use that flag, and
+// NODE_USE_ENV_PROXY would honour NO_PROXY (which typically includes
+// *.cdp-int.defra.cloud) and send the gateway request direct.
+let proxyAgent
+function cdpFetch(url, options) {
+  proxyAgent ??= new ProxyAgent(CDP_PROXY_URL)
+  return fetch(url, { ...options, dispatcher: proxyAgent })
+}
+
 async function getCognitoToken() {
   const tokenUrl = process.env.GATEWAY_TOKEN_URL || DEFAULT_GATEWAY_TOKEN_URL
   const clientId = process.env.GATEWAY_CLIENT_ID
@@ -70,7 +82,7 @@ async function getCognitoToken() {
     client_secret: clientSecret
   })
 
-  const response = await fetch(tokenUrl, {
+  const response = await cdpFetch(tokenUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: form
@@ -92,7 +104,7 @@ async function sendViaGateway(message) {
     'https://marine-licensing-backend.api.test.cdp-int.defra.cloud/queue'
   const token = await getCognitoToken()
 
-  const response = await fetch(queueUrl, {
+  const response = await cdpFetch(queueUrl, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
- Route Cognito token and `/queue` Node fetch calls through Squid at `localhost:3128`, matching Chromium `--proxy-server`
- Fixes `TypeError: fetch failed` in the CDP test env transfer scenario, where native fetch bypassed the proxy
- expose mongodb port for connecting to mongodb compass